### PR TITLE
CentOS install: global paths and faster install

### DIFF
--- a/installer/centos/build.sh
+++ b/installer/centos/build.sh
@@ -1,8 +1,5 @@
 # start with this since it gets input needed
-
-# HNN repo from bitbucket
-#git clone https://bitbucket.org/samnemo/hnn.git# old repo
-
+sudo yum -y install git
 # HNN repo from github - moved to github on April 8, 2018
 git clone https://github.com/jonescompneurolab/hnn.git
 
@@ -48,6 +45,10 @@ sudo python3 setup.py install
 # move outside of nrn directories
 cd $startdir
 
+# cleanup the nrn and iv folders, since NEURON Has been installed
+sudo rm -rf iv
+sudo rm -rf nrn
+
 # setup HNN itself
 cd hnn
 # make compiles the mod files
@@ -56,7 +57,22 @@ export PATH=$PATH:/usr/local/nrn/$CPU/bin
 make
 cd ..
 
+# delete the installed hnn folder in the event that it already exists
+sudo rm -rf /usr/local/hnn
+
+# move the hnn folder to the programs directory
+sudo mv hnn /usr/local
+
+# make the program accessable via the terminal command 'hnn'
+sudo ln -fs /usr/local/hnn/hnn /usr/local/bin/hnn
+
+# create the global session variables, make available for all users
+echo '# these lines define global session variables for HNN' | sudo tee -a /etc/profile.d/hnn.sh
+echo 'export CPU=$(uname -m)' | sudo tee -a /etc/profile.d/hnn.sh
+echo 'export PATH=$PATH::/usr/lib64/openmpi/bin:/usr/local/nrn/$CPU/bin' | sudo tee -a /etc/profile.d/hnn.sh
+
 # qt, pyqt, and supporting packages - needed for GUI
+# SIP unforutnately not available as a wheel for Python 3.4, so have to compile
 wget https://sourceforge.net/projects/pyqt/files/sip/sip-4.19.2/sip-4.19.2.tar.gz
 tar -zxf sip-4.19.2.tar.gz
 cd sip-4.19.2
@@ -64,30 +80,20 @@ sudo python3 configure.py
 make -j4
 sudo make install -j4
 cd ..
+sudo rm -rf sip-4.19.2
 
 sudo yum -y install qt-devel
 sudo yum -y install qt5-qtbase
 sudo yum -y install qt5-qtbase-devel
 
-wget https://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-5.8.2/PyQt5_gpl-5.8.2.tar.gz
-tar -xvf PyQt5_gpl-5.8.2.tar.gz
-cd PyQt5_gpl-5.8.2
-python3 configure.py --qmake=/usr/lib64/qt5/bin/qmake --confirm-license
-make -j4
-sudo make install -j4
-cd ..
+# Have to use --no-deps to get it to install as no SIP wheel available for Python 3.4
+sudo pip3 install pyqt5 --no-deps
 
 # used by pqtgraph - for visualization
 sudo pip3 install PyOpenGL PyOpenGL_accelerate
 
 # pyqtgraph - only used for visualization
-cd hnn
-git clone https://github.com/pyqtgraph/pyqtgraph.git
-cd pyqtgraph
-git checkout pyqt5
-git pull
-sudo python3 setup.py install
+sudo pip3 install pyqtgraph
 
 # needed for matplotlib
 sudo yum -y install python34-tkinter
-


### PR DESCRIPTION
No longer compiling PyQT5 and PyQTGraph. Environment variables updated for all users.