### PR TITLE
uninstall script for CentOS

### DIFF
--- a/installer/centos/uninstall.sh
+++ b/installer/centos/uninstall.sh
@@ -1,0 +1,5 @@
+# Note: this removes HNN itself but none of its dependencies
+
+sudo rm -rf /usr/local/hnn
+sudo rm -f /usr/local/bin/hnn
+sudo rm -f /etc/profile.d/hnn.sh


### PR DESCRIPTION
uninstalls HNN itself, but dependencies are left installed