### PR TITLE
Update Mac install instructions for 10.14 Mojave

### DIFF
--- a/installer/mac/mac-install-instructions.txt
+++ b/installer/mac/mac-install-instructions.txt
@@ -12,7 +12,7 @@ xcode-select --install
 
 # reboot (yes, really)
 
-# go to https://www.continuum.io/downloads and download and install the Python 3.x version (Anaconda distribution) into your Applications folder (currently Python 3.6) (NOTE: you do NOT need to enter your email on the website)
+# go to https://www.anaconda.com/download/ and download and install the Python 3.x version (Anaconda distribution) into your Applications folder (currently Python 3.7)
 
 # open a new terminal window and type the following; enter your password when prompted
 sudo conda update -n base conda
@@ -22,7 +22,9 @@ sudo conda install -y mpi4py
 sudo conda install -y pyqtgraph
 sudo conda install -y PyOpenGL
 
-# go to http://neuron.yale.edu/ftp/neuron/versions/alpha, download and install the most recent version of NEURON into your Applications folder (currently nrn-7.6.master-1712.x86_64-osx.pkg) -- NOTE: say no when asked about setting paths; we'll do that later
+# go to http://neuron.yale.edu/ftp/neuron/versions/alpha to download and install the most recent version of NEURON into your Applications folder
+#   -- NOTE: macOS Mojave (10.14.1) requires nrn-7.6.2-29-g0d801ad.x86_64-osx-py-37-36-27.pkg (or later, built after 2018-10-21)
+#   -- NOTE: say no when asked about setting paths; we'll do that later
 
 
 # to make sure all of the correct paths are followed type the following set of commands to 
@@ -33,13 +35,13 @@ sudo conda install -y PyOpenGL
  # (e.g. type "open ~/.bash_profile" in the terminal without the quotes to edit it):
  export PYTHONPATH=/Applications/NEURON-7.6/nrn/lib/python:$PYTHONPATH
  export PATH=/Applications/NEURON-7.6/nrn/x86_64/bin:$PATH
- export NRN_PYLIB="/Applications/anaconda/bin/../lib//libpython3.6m.dylib"
+ export NRN_PYLIB="~/anaconda3/lib/libpython3.6m.dylib"
 
  # if you are using the c shell (tcsh), put the following in your ~/.cshrc (and/or ~/.tcshrc)
  # (e.g. type "open ~/.cshrc" or as appropriate in the terminal without the quotes to edit the file):
  set PYTHONPATH=(/Applications/NEURON-7.6/nrn/lib/python $PYTHONPATH)
  set path = ($path /Applications/NEURON-7.6/nrn/x86_64/bin)
- set NRN_PYLIB="/Applications/anaconda/bin/../lib//libpython3.6m.dylib"
+ set NRN_PYLIB="~/anaconda3/lib/libpython3.6m.dylib"
 
 # next type the following to clone HNN's github repository (contains model/gui source-code)
 git clone https://github.com/jonescompneurolab/hnn.git


### PR DESCRIPTION
The 10.14 Mojave update makes changes to the readline library that is
loaded by NEURON. The latest alpha release (build date specified in
install doc) has fixed the problem. See discussion:
https://www.neuron.yale.edu/phpBB/viewtopic.php?t=3945

The other changes are related to Anaconda. The old download link is
no longer online and the path for conda installed libraries has
changed. Updated NRN_PYLIB environment variable to reflect new path.