### PR TITLE
WIP - installation to non-system directory - use anaconda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,16 @@ gif
 hnndev
 hnntut
 notes.dol
+
+# PyCharm
+.idea/**
+
+# sublime
+*-e
+
+# Visual Studio Code
+.vscode
+
+# Emacs
+*.py#
+*.rst#

--- a/hnn
+++ b/hnn
@@ -1,2 +1,2 @@
-cd /usr/local/hnn
-python3 /usr/local/hnn/hnn.py /usr/local/hnn/hnn.cfg
+cd ${HNN_ROOT}
+python3 ./hnn.py ./hnn.cfg

--- a/installer/centos/anaconda_installer.sh
+++ b/installer/centos/anaconda_installer.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+# get install prefrix from cmd line
+if test "$#" -ne 1; then
+    echo "please specify an install prefix"
+fi
+
+# expand provided path
+if [[ ! "$1" =~ ^/ ]]
+    then
+        install_prefix="$PWD/$1"
+    else
+        install_prefix="$1"
+fi
+echo "Installing hnn, iv and nrn into $install_prefix"
+
+# check system dependencies.
+# TODO: What else should be checked for
+
+# check that mpicc is on the path
+if ! type -P mpicc &>/dev/null; then
+    echo "mpicc is not in\$PATH"
+    echo "Please install it and add to the PATH environment variable"
+fi
+
+
+# create conda environment
+# TODO: Replace with enviroment.yml file?
+conda create --name hnn python=3 cython scipy numpy matplotlib pyqt pyqtgraph pyopengl libtool=2.4.2
+source activate hnn
+#pip install PyOpenGL_accelerate
+pip install mpi4py
+
+# begin install
+startdir=$(pwd)
+echo $startdir
+
+# download packages
+git clone https://github.com/jonescompneurolab/hnn.git
+git clone https://github.com/neuronsimulator/nrn
+git clone https://github.com/neuronsimulator/iv
+
+# build, configure and install iv
+cd iv
+git checkout d4bb059
+./build.sh
+./configure --prefix=${install_prefix}
+make -j4
+make install -j4
+
+# build, configure and install nrn
+cd ../nrn
+#git checkout be2997e
+./build.sh
+./configure --with-nrnpython=python3 --with-paranrn --with-iv=${install_prefix} --prefix=${install_prefix}
+make -j4
+make install -j4
+cd src/nrnpython
+python3 setup.py install
+
+# cleanup the nrn and iv folders, since NEURON Has been installed
+cd $startdir
+rm -rf iv
+rm -rf nrn
+
+# setup HNN itself
+cd hnn
+# make compiles the mod files
+export CPU=$(uname -m)
+export PATH=$PATH:${install_prefix}/$CPU/bin
+make
+cd ..
+
+# delete the installed hnn folder in the event that it already exists
+rm -rf ${install_prefix}/hnn
+# move the hnn folder to the programs directory
+cp -r hnn ${install_prefix}
+
+# make the program accessable via the terminal command 'hnn'
+ln -fs ${install_prefix}/hnn/hnn ${install_prefix}/${CPU}/bin/hnn
+
+# useful environment variables
+env_setup_fname=${install_prefix}/hnn_profile.sh
+echo '# these lines define global session variables for HNN' | tee -a ${env_setup_fname}
+echo 'export CPU=$(uname -m)' | tee -a ${env_setup_fname}
+echo "install_prefix=${install_prefix}" | tee -a ${env_setup_fname}
+echo 'source activate hnn' | tee -a ${env_setup_fname}
+echo 'export PATH=$PATH:${install_prefix}/$CPU/bin' | tee -a ${env_setup_fname}
+echo 'export HNN_ROOT=${install_prefix}/hnn' | tee -a ${env_setup_fname}
+echo 'export PYTHONPATH=${HNN_ROOT}' | tee -a ${env_setup_fname}

--- a/installer/centos/centos6-installer.sh
+++ b/installer/centos/centos6-installer.sh
@@ -73,6 +73,8 @@ sudo ln -fs /usr/local/hnn/hnn /usr/local/bin/hnn
 echo '# these lines define global session variables for HNN' | sudo tee -a /etc/profile.d/hnn.sh
 echo 'export CPU=$(uname -m)' | sudo tee -a /etc/profile.d/hnn.sh
 echo 'export PATH=$PATH::/usr/lib64/openmpi/bin:/usr/local/nrn/$CPU/bin' | sudo tee -a /etc/profile.d/hnn.sh
+echo 'export HNN_ROOT=/usr/local/hnn' | tee -a /etc/profile.d/hnn.sh
+
 
 # qt, pyqt, and supporting packages - needed for GUI
 # SIP unforutnately not available as a wheel for Python 3.4, so have to compile

--- a/installer/centos/centos7-installer.sh
+++ b/installer/centos/centos7-installer.sh
@@ -73,6 +73,7 @@ sudo ln -fs /usr/local/hnn/hnn /usr/local/bin/hnn
 echo '# these lines define global session variables for HNN' | sudo tee -a /etc/profile.d/hnn.sh
 echo 'export CPU=$(uname -m)' | sudo tee -a /etc/profile.d/hnn.sh
 echo 'export PATH=$PATH:/usr/lib64/openmpi/bin:/usr/local/nrn/$CPU/bin' | sudo tee -a /etc/profile.d/hnn.sh
+echo 'export HNN_ROOT=/usr/local/hnn' | tee -a /etc/profile.d/hnn.sh
 
 # qt, pyqt, and supporting packages - needed for GUI
 # SIP unforutnately not available as a wheel for Python 3.4, so have to compile

--- a/installer/ubuntu/installer.sh
+++ b/installer/ubuntu/installer.sh
@@ -81,3 +81,4 @@ sudo updatedb
 echo '# these lines define global session variables for HNN'
 echo 'export CPU=$(uname -m)' >> ~/.bashrc
 echo 'export PATH=$PATH:/usr/local/nrn/$CPU/bin' >> ~/.bashrc
+echo 'export HNN_ROOT=/usr/local/hnn' >> ~/.bashrc


### PR DESCRIPTION
This
1) uses anaconda to standardize python installation.
2) installs hnn, iv and nrn to a non-system directory, so doesn't need sudo.
3) uses environment variable `HNN_ROOT` to identify where hnn's root src directory is.



closes issue #25 (@jasmainak)