### PR TITLE
[WIP] Use HNN_ROOT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,16 @@ gif
 hnndev
 hnntut
 notes.dol
+
+# PyCharm
+.idea/**
+
+# sublime
+*-e
+
+# Visual Studio Code
+.vscode
+
+# Emacs
+*.py#
+*.rst#

--- a/hnn
+++ b/hnn
@@ -1,2 +1,15 @@
-cd /usr/local/hnn
-python3 /usr/local/hnn/hnn.py /usr/local/hnn/hnn.cfg
+#!/bin/bash
+
+if [[ -z ${HNN_ROOT} ]]; then
+    export HNN_ROOT=/usr/local/hnn
+fi
+
+if [[ ! -f ${HNN_ROOT}/hnn.py ]]; then
+    echo "Error Can't find hnn.py in ${HNN_ROOT}"
+    echo "Please check installation and set HNN_ROOT environment variable appropriately"
+fi
+
+_cwd=`pwd`
+cd ${HNN_ROOT}
+python3 ./hnn.py ./hnn.cfg
+cd ${_cwd}

--- a/installer/centos/centos6-installer.sh
+++ b/installer/centos/centos6-installer.sh
@@ -73,6 +73,7 @@ sudo ln -fs /usr/local/hnn/hnn /usr/local/bin/hnn
 echo '# these lines define global session variables for HNN' | sudo tee -a /etc/profile.d/hnn.sh
 echo 'export CPU=$(uname -m)' | sudo tee -a /etc/profile.d/hnn.sh
 echo 'export PATH=$PATH::/usr/lib64/openmpi/bin:/usr/local/nrn/$CPU/bin' | sudo tee -a /etc/profile.d/hnn.sh
+echo 'export HNN_ROOT=/usr/local/hnn' | sudo tee -a /etc/profile.d/hnn.sh
 
 # qt, pyqt, and supporting packages - needed for GUI
 # SIP unforutnately not available as a wheel for Python 3.4, so have to compile

--- a/installer/centos/centos7-installer.sh
+++ b/installer/centos/centos7-installer.sh
@@ -73,6 +73,7 @@ sudo ln -fs /usr/local/hnn/hnn /usr/local/bin/hnn
 echo '# these lines define global session variables for HNN' | sudo tee -a /etc/profile.d/hnn.sh
 echo 'export CPU=$(uname -m)' | sudo tee -a /etc/profile.d/hnn.sh
 echo 'export PATH=$PATH:/usr/lib64/openmpi/bin:/usr/local/nrn/$CPU/bin' | sudo tee -a /etc/profile.d/hnn.sh
+echo 'export HNN_ROOT=/usr/local/hnn' | sudo tee -a /etc/profile.d/hnn.sh
 
 # qt, pyqt, and supporting packages - needed for GUI
 # SIP unforutnately not available as a wheel for Python 3.4, so have to compile

--- a/installer/ubuntu/installer.sh
+++ b/installer/ubuntu/installer.sh
@@ -81,3 +81,4 @@ sudo updatedb
 echo '# these lines define global session variables for HNN'
 echo 'export CPU=$(uname -m)' >> ~/.bashrc
 echo 'export PATH=$PATH:/usr/local/nrn/$CPU/bin' >> ~/.bashrc
+echo 'export HNN_ROOT=/usr/local/hnn' >> ~/.bashrc


### PR DESCRIPTION
use HNN_ROOT in hnn launcher script

This seemed like the most straight forward way to have hnn live in a non /usr/local directory.

Certainly open to other suggestions.