### PR TITLE
Clarify commands to start hnn on Windows

### DIFF
--- a/installer/windows/hnn.ps1
+++ b/installer/windows/hnn.ps1
@@ -486,12 +486,19 @@ else {
 Write-Host ""
 Write-Host "Finished installing HNN and prerequisites."
 Write-Host "Activate the environment from cmd.exe (not Powershell):"
+Write-Host ""
+
 if ($null -ne $script:CONDA_PATH)  {
+  if ($script:installMiniconda) {
+    Write-Host "# *** run the commands below from a new command prompt or 'conda' will not be found ****"
+  }
   Write-Host "conda activate hnn"
 }
 elseif ($null -ne $script:VIRTUALENV) {
   Write-Host "$HOME\venv\hnn\Scripts\activate"
 }
-Write-Host "python $HNN_PATH\hnn.py $HNN_PATH\hnn.cfg"
+Write-Host "cd $HNN_PATH"
+Write-Host "python hnn.py hnn.cfg"
+Write-Host ""
 
 return


### PR DESCRIPTION
I realized that the powershell install script wasn't properly instructing users to change their working directory to the hnn repo before starting the GUI. These changes will output the correct instructions for users.