### PR TITLE
Make docker container more usable and use Docker Hub image

### DIFF
--- a/installer/docker/Dockerfile
+++ b/installer/docker/Dockerfile
@@ -13,7 +13,8 @@ RUN apt-get update && \
                        python3-opengl zlib1g-dev zlib1g zlibc libx11-dev mercurial \
                        bison flex automake libtool libxext-dev libncurses-dev \
                        python3-dev xfonts-100dpi cython libopenmpi-dev python3-scipy \
-                       python3-pyqt4.qtopengl libxaw7 libxmu6 libxpm4 && \
+                       python3-pyqt4.qtopengl libxaw7 libxmu6 libxpm4 \
+                       git vim iputils-ping net-tools iproute2 nano sudo && \
     apt-get remove -y python3-matplotlib
 
 # use pip for matplotlib to get latest version (2.x) since apt-get was using older
@@ -22,7 +23,17 @@ RUN apt-get update && \
 RUN pip3 install PyOpenGL matplotlib && \
     pip3 install --upgrade PyOpenGL matplotlib
 
+# create the group hnn_group and user hnn_user
 RUN groupadd hnn_group && useradd -m -b /home/ -g hnn_group hnn_user
+
+# add hnn_user to the sudo group
+RUN adduser hnn_user sudo
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# copy the start script into the container
+COPY start_hnn_in_docker.sh /home/hnn_user/
+RUN sudo chown hnn_user:hnn_group /home/hnn_user/start_hnn_in_docker.sh && \
+    sudo chmod +x /home/hnn_user/start_hnn_in_docker.sh
 
 USER hnn_user
 # install NEURON dependencies
@@ -69,5 +80,7 @@ RUN cd /home/hnn_user/iv && \
     cd /home/hnn_user/nrn && \
     make clean
 
+# if users open up a shell, they should go to the hnn repo checkout
 WORKDIR /home/hnn_user/hnn
-CMD python3 hnn.py hnn.cfg
+
+CMD /home/hnn_user/start_hnn_in_docker.sh

--- a/installer/docker/docker-compose.yml
+++ b/installer/docker/docker-compose.yml
@@ -2,7 +2,6 @@ version: "3"
 services:
 
   hnn:
-    build: .
     image: jonescompneurolab/hnn
     environment:
       XAUTHORITY: "/.Xauthority"
@@ -10,4 +9,4 @@ services:
     volumes:
       - "$HOME/.Xauthority:/.Xauthority"
       - "/tmp/.X11-unix:/tmp/.X11-unix"
-    command: python3 hnn.py hnn.cfg
+    command: /home/hnn_user/start_hnn_in_docker.sh

--- a/installer/docker/start_hnn_in_docker.sh
+++ b/installer/docker/start_hnn_in_docker.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cd /home/hnn_user/hnn
+python3 hnn.py hnn.cfg
+
+# fallback to sleep infinity so that container won't stop if hnn is closed
+sleep infinity

--- a/installer/windows/windows-install.md
+++ b/installer/windows/windows-install.md
@@ -68,24 +68,22 @@ https://docs.docker.com/toolbox/toolbox_install_windows/
     git clone https://github.com/jonescompneurolab/hnn.git
     cd hnn\installer\docker
     ```
-4. Build start the Docker container. Note: build may take more than 10 minutes
+4. Start the Docker container. Note: the jonescompneurolab/hnn docker image will be downloaded from Docker Hub (about 1.5 GB)
     ```
-    docker-compose build
     docker-compose up -d
     ```
 5. A prompt from the dock will ask you to share the drive. Click 'Share'
 6. The HNN GUI should show up and you should now be able to run the tutorials at: https://hnn.brown.edu/index.php/tutorials/
-7. **NOTE:** To access a command prompt in the container, use `docker exec`:
+7. **NOTE:** You may want to edit files within the container. To access a command prompt in the container, use `docker exec`:
     ```
     docker exec -ti docker_hnn_1 bash
     ```
+    If you'd like to be able to access files from the host Windows system within the container, you can either copy files with [docker cp](https://docs.docker.com/engine/reference/commandline/cp/) or start the container with host directory that is visible as a "volume" within the container (instead of step 4):
+    ```
+    mkdir %HOME%\dir_on_host
+    docker-compose run -d -v %HOME%\dir_on_host:/home/hnn_user/dir_from_host hnn
+    ```
 
-
-
-
-
-
-[](https://docs.docker.com/docker-for-windows/install/)
 ## Native Install
 
 The [HNN install powershell script](hnn.ps1) will manage downloading all prerequisites except Microsoft MPI which requires a web browser to download. If the script finds msmpisetup.exe in the Downloads folder, it will take care of installing it.


### PR DESCRIPTION
The Windows install instructions expect that a docker pull from jonescompneurolab/hnn will succeed.

Summary:
 - Pull prebuilt image from Docker Hub
 - Basic packages (git, vim, ping, etc.) added to the image
 - Give sudo to the hnn_user
 - Keep container alive even after HNN GUI is closed
 - Update Windows installation instructions for docker