### PR TITLE
Use markdown for all instructions including Docker

### DIFF
--- a/installer/centos/README.md
+++ b/installer/centos/README.md
@@ -1,0 +1,62 @@
+# Installing HNN on CentOS
+
+This guide describes two methods for installing HNN and its prerequisistes CentOS (tested on CentOS 7):
+
+1. A Docker container running a Linux install of HNN (recommended, CentOS 7 only) 
+2. Natively running HNN on CentOS 6 or 7 (better performance)
+
+The Docker installation is recommended because the python environment and the NEURON installation are fully isolated, reducing the possibility of version conflicts, or the wrong version being used. The same Docker container is used for all platforms (Windows/Linux/Mac) meaning it has likely been tested more recently.
+
+## Install Docker
+* Follow [Docker's CentOS install instructions](https://docs.docker.com/install/linux/docker-ce/centos/) to install the docker-ce RPM packages from Docker's official repository
+* Add your user to the docker group to avoid having to run docker commands with "sudo"
+    ```
+    sudo usermod -a -G docker [username]
+    ```
+* Log out and back in for the group change to take effect
+
+## Install Docker Compose
+* From https://docs.docker.com/compose/install/:
+    ```
+    sudo curl -L "https://github.com/docker/compose/releases/download/1.23.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    sudo chmod +x /usr/local/bin/docker-compose
+    docker-compose --version
+    ```
+
+### Start the HNN Docker container
+1. Clone or download the [HNN repo](https://github.com/jonescompneurolab/hnn):
+    ```
+    git clone https://github.com/jonescompneurolab/hnn.git
+    cd hnn/installer/docker
+    ```
+2. Start the Docker container. Note: the jonescompneurolab/hnn docker image will be downloaded from Docker Hub (about 1.5 GB)
+    ```
+    docker-compose up -d
+    ```    
+3. The HNN GUI should show up and you should now be able to run the tutorials at: https://hnn.brown.edu/index.php/tutorials/
+   * If you run into problems starting the Docker container or the GUI is not displaying, please see the [Docker troubleshooting section](../docker/README.md#Troubleshooting)
+   * If you closed the HNN GUI, and would like to restart it, run the following:
+      ```
+      docker-compose restart
+      ```
+4. **NOTE:** You may want to edit files within the container. To access a command prompt in the container, use `docker exec`:
+    ```
+    docker exec -ti docker_hnn_1 bash
+    ```
+    If you'd like to be able to access files from the host system within the container, you can either copy files with [docker cp](https://docs.docker.com/engine/reference/commandline/cp/) or start the container with host directory that is visible as a "volume" within the container (instead of step 4):
+    ```
+    mkdir $HOME/dir_on_host
+    docker-compose run -d -v $HOME/dir_on_host:/home/hnn_user/dir_from_host hnn
+    ```
+    * Note the different container name after running docker-compose
+
+## Native install scripts
+
+See the scripts in this directory:
+* CentOS 6: [centos6-installer.sh](centos6-installer.sh)
+* CentOS 7: [centos7-installer.sh](centos7-installer.sh)
+
+```
+chmod +x ./centos7-installer.sh
+./centos7-installer.sh
+```

--- a/installer/docker/README.md
+++ b/installer/docker/README.md
@@ -1,0 +1,69 @@
+# HNN Docker container
+
+This directory contains files for building he HNN container and using docker-compose to start the container on any platform. The container itself is running the Ubuntu 18.04 Linux distribution, but can run on any Operating system assuming that [Docker](https://www.docker.com/) is installed. For more specific instructions on installing Docker and starting the container, see one of the following pages that matches your operating system:
+ * [Windows](../windows)
+ * [Mac](../mac)
+ * [Ubuntu](../ubuntu)
+ * [CentOS](../centos)
+
+## Pulling the prebuilt Docker container from Docker Hub
+The newest version of HNN is available as a prebuilt container posted on Docker Hub, which can be used instead of building the container and all of its prerequisites (NEURON) from scratch.
+```
+docker pull jonescompneurolab/hnn
+```
+
+## Building HNN container from this directory
+```
+cd hnn/installer/docker
+docker build --tag jonescompneurolab/hnn .
+```
+
+## Running HNN container without docker-compose
+Using docker-compose is the preferred way to run HNN containers, because it sets needed environment variables and defines volumes automatically. However, if docker-compose is not available or the user wants to modify docker run arguments, the following command Replicates behavior by docker-compose:
+```
+# Set DISPLAY on Mac 
+export DISPLAY=$(ifconfig en0 | awk '/inet /{print $2 ":0"}')
+# Set DISPLAY on Windows
+set DISPLAY=10.0.75.1:0
+# Start container
+docker run -d -e XAUTHORITY="/.Xauthority" -e DISPLAY -v ~/.Xauthority:/.Xauthority -v /tmp/.X11-unix:/tmp/.X11-unix jonescompneurolab/hnn /home/hnn_user/start_hnn_in_docker.sh
+```
+
+## Troubleshooting
+
+Common problems that one might encounter running the HNN docker container are listed below. Some of the links below go to an external site (e.g. MetaCell) because they provided an explanation of the problem and the appropriate fix.
+ ### Problem: [This computer doesn't have VT-x/AMD-v enabled. (MetaCell documentation)](https://github.com/MetaCell/NetPyNE-UI/wiki/Docker-installation#problem-this-computer-doesnt-have-vt-xamd-v-enabled)
+ ### Problem: [Image operating system linux cannot be used on this platform (MetaCell documentation)](https://github.com/MetaCell/NetPyNE-UI/wiki/Docker-installation#problem-image-operating-system-linux-cannot-be-used-on-this-platform)
+ 
+ ### Problem: GUI is not displaying after starting the Docker container
+
+The first thing is to check for any errors in starting the Docker container. Check the logs for the container using:
+```
+docker logs docker_hnn_1
+```
+If HNN fails to start, the startup script will fall back to running the command "sleep infinity" which allows you to open up a shell in the container and debug what went wrong. An example of not being able to connect to the X server:
+
+    QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-hnn_user'
+    qt.qpa.screen: QXcbConnection: Could not connect to display 10.0.75.1:0
+    Could not connect to any X display.
+
+* The first line is not indicative of any error, and is always present. In this case, the next two lines indicate that the X display for HNN GUI was not started. Check for connectivity from within the container to the address given. This may be because of firewalls or an incorrect IP address. When in doubt, an IP address of the external interface (e.g. wireless)will work in most cases.
+
+
+If the error messages are different than above, open a shell in the container:
+```
+docker exec -ti docker_hnn_1 bash
+```
+Check which processes are running:
+```
+ps auxw
+```
+If HNN hasn't started, try starting it manually:
+```
+python3 hnn.py hnn.cfg
+```
+
+
+## Note on Linux X Windows for the GUI
+
+The Linux HNN container uses the X11 protocol to display its GUI on the above platforms. This requires an X server to be installed on the host operating system. Since the container will be communicating via this protocol, it needs to know both the IP address of the X server and also be authorized to use the display. The IP address is passed into the container using the environment variable DISPLAY and the authorization issue is sidestepped by making the file ~/.Xauthority from the host available within the container. A more secure but slightly less user-friendly set up would be to use the xhost command on the host operating system to authorize the container's use of the display. This command may not be available on MS Windows systems, so the provided instructions use the .Xauthority file method instead.

--- a/installer/mac/README.md
+++ b/installer/mac/README.md
@@ -1,0 +1,80 @@
+# Installing HNN on Mac OS
+
+There are two methods for installing HNN and its prerequisistes on Mac OS (tested on High Sierra):
+
+1. A Docker container running a Linux install of HNN (recommended)
+2. Natively running HNN on Mac OS (better performance)
+
+The Docker installation is recommended because the python environment and the NEURON installation are fully isolated, reducing the possibility of version conflicts, or the wrong version being used. The same Docker container is used for all platforms (Windows/Linux/Mac) meaning it has likely been tested more recently.
+
+Both methods display the GUI through an X server. Differences in performance may be due to overhead from running and container (especially using Docker Toolbox in Which Docker Runs in a Virtual Machine)
+
+## Docker Install
+
+[Docker Desktop](https://www.docker.com/products/docker-desktop) requires Mac OS Sierra 10.12 or above. For earlier versions of Mac OS, use the legacy version of [Docker Toolbox](https://docs.docker.com/toolbox/overview/).
+
+The only other component to install is an X server. [XQuartz](https://www.xquartz.org/) is a recommended free option.
+
+### Install XQuartz
+1. Download the installer image (version 2.7.11 tested): https://www.xquartz.org/
+2. Run the XQuartz.pkg installer within the image, granting privileges when requested.
+3. Start the XQuartz application. An "X" icon will appear in the taskbar along with a terminal, signaling that XQuartz is waiting for connections. You can minimize the terminal, but do not close it.
+
+### Install Docker Desktop (Mac OS Sierra 10.12 or above)
+1. Download the installer image (requires a free Docker Hub account):
+https://hub.docker.com/editions/community/docker-ce-desktop-mac
+2. Run the Docker Desktop installer, moving docker to the applications folder.
+3. Start the Docker application, acknowledging that it was downloaded from the Internet and you still want to open it.
+4. The Docker Desktop icon will appear in the taskbar with the message "Docker Desktop is starting", Followed by "Docker Desktop is running".
+
+### Install Docker Toolbox (pre-10.12)
+1. Download the installer image:
+https://docs.docker.com/toolbox/toolbox_install_mac/
+2. Run the installer, selecting any directory for installation.
+3. Choose "Docker Quickstart Terminal" tool
+4. Verify that Docker has started by running the following in the provided terminal window. 
+    ```
+    docker info
+    docker-compose --version
+    ```
+5. Run the following commands in the same terminal window or by relaunching "Docker Quickstart Terminal".
+
+### Start the HNN Docker container
+1. Get the IP address of a local interface on the host(e.g. using ifconfig)
+    * For Docker Toolbox you can use interface that will be named similar to vboxnet1 with an IP address such as 192.168.99.1
+    * For Docker Desktop an additional interface is not created, so you'll have to use one that's in existence already. Ideally, find one that belongs to a local interface that will not go away when you connection disappears. If there are no other options besides your external network interface, you can get its IP address using:
+    ```
+    export IP=$(ifconfig en0 | awk '$1 == "inet" {print $2}')
+2. Set an environment variable DISPLAY containing "[IP address]:0"
+    ```
+    export DISPLAY=$IP:0
+    ```
+3. Clone or download the [HNN repo](https://github.com/jonescompneurolab/hnn):
+    ```
+    git clone https://github.com/jonescompneurolab/hnn.git
+    cd hnn/installer/docker
+    ```
+4. Start the Docker container. Note: the jonescompneurolab/hnn docker image will be downloaded from Docker Hub (about 1.5 GB)
+    ```
+    docker-compose up -d
+    ```    
+5. The HNN GUI should show up and you should now be able to run the tutorials at: https://hnn.brown.edu/index.php/tutorials/
+   * If you run into problems starting the Docker container or the GUI is not displaying, please see the [Docker troubleshooting section](../docker/README.md#Troubleshooting)
+   * If you closed the HNN GUI, and would like to restart it, run the following:
+      ```
+      docker-compose restart
+      ```
+6. **NOTE:** You may want to edit files within the container. To access a command prompt in the container, use `docker exec`:
+    ```
+    docker exec -ti docker_hnn_1 bash
+    ```
+    If you'd like to be able to access files from the host system within the container, you can either copy files with [docker cp](https://docs.docker.com/engine/reference/commandline/cp/) or start the container with host directory that is visible as a "volume" within the container (instead of step 4):
+    ```
+    mkdir $HOME/dir_on_host
+    docker-compose run -d -v $HOME/dir_on_host:/home/hnn_user/dir_from_host hnn
+    ```
+    * Note the different container name after running docker-compose
+
+## Native install
+
+See the instructions in the file [mac-install-instructions.txt](mac-install-instructions.txt)

--- a/installer/ubuntu/README.md
+++ b/installer/ubuntu/README.md
@@ -1,0 +1,65 @@
+# Installing HNN on Ubuntu
+
+This guide describes two methods for installing HNN and its prerequisistes Ubuntu (tested on Ubuntu 18.04 LTS):
+
+1. A Docker container running a Linux install of HNN (recommended)
+   * See [OS requirements](https://docs.docker.com/install/linux/docker-ce/ubuntu/#os-requirements)
+2. Natively running HNN on Ubuntu (better performance)
+
+The Docker installation is recommended because the python environment and the NEURON installation are fully isolated, reducing the possibility of version conflicts, or the wrong version being used. The same Docker container is used for all platforms (Windows/Linux/Mac) meaning it has likely been tested more recently.
+
+## Install Docker
+* Follow [Docker's Ubuntu install instructions](https://docs.docker.com/install/linux/docker-ce/ubuntu/) to install the docker-ce packages from Docker's official repository
+* Add your user to the docker group to avoid having to run docker commands with "sudo"
+    ```
+    sudo usermod -a -G docker [username]
+    ```
+* Log out and back in (may need to reboot) for the group change to take effect
+
+## Install Docker Compose
+* From https://docs.docker.com/compose/install/:
+    ```
+    sudo curl -L "https://github.com/docker/compose/releases/download/1.23.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    sudo chmod +x /usr/local/bin/docker-compose
+    docker-compose --version
+    ```
+
+### Start the HNN Docker container
+1. Clone or download the [HNN repo](https://github.com/jonescompneurolab/hnn):
+    ```
+    git clone https://github.com/jonescompneurolab/hnn.git
+    cd hnn/installer/docker
+    ```
+2. Start the Docker container. Note: the jonescompneurolab/hnn docker image will be downloaded from Docker Hub (about 1.5 GB)
+    ```
+    docker-compose up -d
+    ```    
+3. The HNN GUI should show up and you should now be able to run the tutorials at: https://hnn.brown.edu/index.php/tutorials/
+   * If you run into problems starting the Docker container or the GUI is not displaying, please see the [Docker troubleshooting section](../docker/README.md#Troubleshooting)
+   * If you closed the HNN GUI, and would like to restart it, run the following:
+      ```
+      docker-compose restart
+      ```
+4. **NOTE:** You may want to edit files within the container. To access a command prompt in the container, use `docker exec`:
+    ```
+    docker exec -ti docker_hnn_1 bash
+    ```
+    If you'd like to be able to access files from the host system within the container, you can either copy files with [docker cp](https://docs.docker.com/engine/reference/commandline/cp/) or start the container with host directory that is visible as a "volume" within the container (instead of step 4):
+    ```
+    mkdir $HOME/dir_on_host
+    docker-compose run -d -v $HOME/dir_on_host:/home/hnn_user/dir_from_host hnn
+    ```
+    * Note the different container name after running docker-compose
+
+## Native install script
+
+See the script in this directory:
+* [installer.sh](installer.sh)
+* [uninstaller.sh](uninstaller.sh)
+* [updater.sh](updater.sh)
+
+
+```
+chmod +x ./installer.sh
+./installer.sh
+```

--- a/installer/windows/README.md
+++ b/installer/windows/README.md
@@ -2,16 +2,16 @@
 
 This guide describes two methods for installing HNN and its prerequisistes on a Windows 10 system:
 
-1. A docker container running a Linux install of HNN (recommended)
+1. A Docker container running a Linux install of HNN (recommended)
 2. Natively running HNN on Windows (better performance)
 
-The docker installation is recommended because the python environment and the NEURON installation are fully isolated, reducing the possibility of version conflicts, or the wrong version being used. The same Docker container is used for all platforms (Windows/Linux/Mac) meaning it has likely been tested more recently.
+The Docker installation is recommended because the python environment and the NEURON installation are fully isolated, reducing the possibility of version conflicts, or the wrong version being used. The same Docker container is used for all platforms (Windows/Linux/Mac) meaning it has likely been tested more recently.
 
-Method 1 (using Docker) displays the GUI through an X windows server which may lead to slower responsiveness as compared to using method 2, which displays the GUI running natively on Windows.
+Method 1 (using Docker) displays the GUI through an X server which may lead to slower responsiveness as compared to using method 2, which displays the GUI running natively on Windows.
 
-## Docker Install
+## Docker install
 
-[Docker Desktop](https://www.docker.com/products/docker-desktop) for Windows 10 (Pro/Enterprise only) is capable of running both Linux containers and Windows containers. For HNN's GUI to display properly, only Linux containers work. Docker Desktop is installed with this configuration by default.  For Windows 10 Home or other versions of windows, use the legacy version of [Docker Toolbox](https://docs.docker.com/toolbox/toolbox_install_windows/).
+[Docker Desktop](https://www.docker.com/products/docker-desktop) for Windows 10 (Pro/Enterprise only) is capable of running both Linux containers and Windows containers. For HNN's GUI to display properly, only Linux containers work. Docker Desktop is installed with this configuration by default.  For Windows 10 Home or other versions of windows, use the legacy version of [Docker Toolbox](https://docs.docker.com/toolbox/overview/).
 
 The only other component to install is an X server. Both [VcXsrv](https://sourceforge.net/projects/vcxsrv/) and [Xming](https://sourceforge.net/projects/xming/) are recommended free options. These install instructions will cover VcXsrv.
 
@@ -23,6 +23,8 @@ The only other component to install is an X server. Both [VcXsrv](https://source
 5. Select "Start no client" and click 'Next'.
 6. Under "Extra settings" make sure that "Disable access control" is checked.
 7. Click "Finish" and an "X" icon will appear in the lower-right dock signaling that VcXsrv is waiting for connections.
+8. A message from Windows firewall to allow connections may pop up. If it does, choose options allowing connections to the VcXsrv when connected to both public and private networks.
+
 
 ### Install Docker Desktop (Windows 10 Pro/Enterprise)
 1. Download the installer (requires a free Docker Hub account):
@@ -45,46 +47,51 @@ https://docs.docker.com/toolbox/toolbox_install_windows/
 6. Run the commands below from a new cmd.exe window.
 
 ### Start the HNN Docker container
-1. Open a cmd.exe window and run `ipconfig` to get your external IPv4 address e.g. "Wireless LAN adapter Wi-Fi 2" 
+1. Verify that the docker interface on your system has an IP address of 10.0.75.1. If you see a different IP address from the output of ipconfig, use that instead. Open a cmd.exe window and run `ipconfig`. The output should be similar to below. If the IP address differs from 10.0.75.1, you need to correct it in [docker-compose.yml](../docker/docker-compose.yml).
     ```
-    C:\Users\myuser>ipconfig
+    C:\Users\[USER]>ipconfig
 
     Windows IP Configuration
-    ...
-    Wireless LAN adapter Wi-Fi 2:
+
+
+    Ethernet adapter vEthernet (DockerNAT):
 
        Connection-specific DNS Suffix  . :
-       ...
-       IPv4 Address. . . . . . . . . . . : 192.168.0.16
+       IPv4 Address. . . . . . . . . . . : 10.0.75.1
        Subnet Mask . . . . . . . . . . . : 255.255.255.0
-       ...
+       Default Gateway . . . . . . . . . :
+
     ```
-2. Set an environment variable DISPLAY containing "[IP address]:0" (e.g. `192.168.0.16:0`)
-    ```
-    set DISPLAY=[external IPv4 address]:0
-    ```
-3. Clone or download the [HNN repo](https://github.com/jonescompneurolab/hnn). Assuming [Git for Windows](https://gitforwindows.org/) is installed, type the following in a cmd.exe window:
+2. Clone or download the [HNN repo](https://github.com/jonescompneurolab/hnn). Assuming [Git for Windows](https://gitforwindows.org/) is installed, type the following in a cmd.exe window:
     ```
     git clone https://github.com/jonescompneurolab/hnn.git
-    cd hnn\installer\docker
+    cd hnn\installer\windows
     ```
-4. Start the Docker container. Note: the jonescompneurolab/hnn docker image will be downloaded from Docker Hub (about 1.5 GB)
+3. Start the Docker container. Note: the jonescompneurolab/hnn docker image will be downloaded from Docker Hub (about 1.5 GB)
     ```
     docker-compose up -d
     ```
-5. A prompt from the dock will ask you to share the drive. Click 'Share'
-6. The HNN GUI should show up and you should now be able to run the tutorials at: https://hnn.brown.edu/index.php/tutorials/
-7. **NOTE:** You may want to edit files within the container. To access a command prompt in the container, use `docker exec`:
+4. A prompt from the dock will ask you to share the drive. Click 'Share'
+5. The HNN GUI should show up and you should now be able to run the tutorials at: https://hnn.brown.edu/index.php/tutorials/
+
+   * If you run into problems starting the Docker container or the GUI is not displaying, please see the [Docker troubleshooting section](../docker/README.md#Troubleshooting)
+   * If you closed the HNN GUI, and would like to restart it, run the following:
+      ```
+      docker-compose restart
+      ```
+
+6. **NOTE:** You may want to edit files within the container. To access a command prompt in the container, use `docker exec`:
     ```
     docker exec -ti docker_hnn_1 bash
     ```
-    If you'd like to be able to access files from the host Windows system within the container, you can either copy files with [docker cp](https://docs.docker.com/engine/reference/commandline/cp/) or start the container with host directory that is visible as a "volume" within the container (instead of step 4):
+    If you'd like to be able to access files from the host Windows system within the container, you can either copy files with [docker cp](https://docs.docker.com/engine/reference/commandline/cp/) or start the container with host directory that is visible as a "volume" within the container (instead of step 3):
     ```
     mkdir %HOME%\dir_on_host
     docker-compose run -d -v %HOME%\dir_on_host:/home/hnn_user/dir_from_host hnn
     ```
+    * Note the different container name after running docker-compose
 
-## Native Install
+## Native install script
 
 The [HNN install powershell script](hnn.ps1) will manage downloading all prerequisites except Microsoft MPI which requires a web browser to download. If the script finds msmpisetup.exe in the Downloads folder, it will take care of installing it.
 

--- a/installer/windows/docker-compose.yml
+++ b/installer/windows/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+
+  hnn:
+    image: jonescompneurolab/hnn
+    environment:
+      XAUTHORITY: "/.Xauthority"
+      DISPLAY: "10.0.75.1:0"
+    volumes:
+      - "$HOME/.Xauthority:/.Xauthority"
+      - "/tmp/.X11-unix:/tmp/.X11-unix"
+    command: /home/hnn_user/start_hnn_in_docker.sh


### PR DESCRIPTION
This commit includes instructions for using the Docker container on
each platform (CentOS/Ubuntu/Mac/Windows). The instructions have been
updated to recommend an IP address that will not go away as external
network connectivity changes. This means that the HNN GUI will remain
running even after a laptop screen is closed or Wi-Fi locations have
changed.

The procedure for Windows is slightly simplified by using a consistent
IP address for the DISPLAY environment variable. Docker Desktop will
create this interface and it will likely be the same for all users.