### PR TITLE
Split install instructions into different files

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -5,3 +5,6 @@ This directory contains instructions and files supporting installation of HNN on
  * [Mac](mac)
  * [Ubuntu](ubuntu)
  * [CentOS](centos)
+
+ If you are running into problems with the instructions given for your machine, we recommed using the VirtualBox VM with HNN pre-installed. Instructions for this downloading and running this VM can be found at the following link (Click 'VirtualBox'):
+ * [HNN VirtualBox install instructions](https://hnn.brown.edu/index.php/installation-instructions/)

--- a/installer/centos/README.md
+++ b/installer/centos/README.md
@@ -1,17 +1,9 @@
-# Installing HNN on CentOS
+# Installing HNN on CentOS (Docker install)
 
-This guide describes two methods for installing HNN and its prerequisites CentOS (tested on CentOS 7):
+This guide describes installing HNN on CentOS using Docker. This method will automatically download the HNN Docker container image when HNN is started for the first time. If you would prefer to install HNN without Docker, please see the instructions below.
+  - Alternative: [Native install instructions (advanced users)](native_install.md)
 
-Method 1: A Docker container running a Linux install of HNN (recommended)
-   - The Docker installation fully isolates HNN's python environment and the NEURON installation from the rest of your system, reducing the possibility of version incompatibilities. Additionally, the same Docker container is used for all platforms (Windows/Linux/Mac) meaning it has likely been tested more recently.
-   - See [OS requirements](https://docs.docker.com/install/linux/docker-ce/ubuntu/#os-requirements)
-
-Method 2: Natively running HNN on CentOS 6 or 7 (advanced users)
-   - HNN runs directly on the OS and uses a script to download and install prerequisites. It is more difficult to control the native environment than in Method 1 (with Docker), so it's possible that the script will need user intervention. Thus, Method 2 is best suited for advanced users.
-
-## Method 1: Docker install
-
-### Prerequisite: install Docker
+## Prerequisite: install Docker
 * Follow [Docker's CentOS install instructions](https://docs.docker.com/install/linux/docker-ce/centos/) to install the docker-ce RPM packages from Docker's official repository
 * Add your user to the docker group to avoid having to run docker commands with "sudo"
     ```
@@ -19,7 +11,7 @@ Method 2: Natively running HNN on CentOS 6 or 7 (advanced users)
     ```
 * Log out and back in for the group change to take effect
 
-### Prerequisite: install Docker Compose
+## Prerequisite: install Docker Compose
 * From https://docs.docker.com/compose/install/:
     ```
     sudo curl -L "https://github.com/docker/compose/releases/download/1.23.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
@@ -27,7 +19,8 @@ Method 2: Natively running HNN on CentOS 6 or 7 (advanced users)
     docker-compose --version
     ```
 
-### Start HNN
+## Start HNN
+
 1. Check that Docker is running properly by typing the following in a new terminal window.
     ```
     docker info
@@ -56,16 +49,8 @@ Method 2: Natively running HNN on CentOS 6 or 7 (advanced users)
 
     If you'd like to be able to copy files from the host OS without using the shared directory, you do so directly with [`docker cp`](https://docs.docker.com/engine/reference/commandline/cp/).
 
-## Method 2: native install
-See the scripts in this directory:
-* CentOS 6: [centos6-installer.sh](centos6-installer.sh)
-* CentOS 7: [centos7-installer.sh](centos7-installer.sh)
-  ```
-  chmod +x ./centos7-installer.sh
-  ./centos7-installer.sh
-  ```
-* [uninstall.sh](uninstall.sh)
-  ```
-  chmod +x ./uninstall.sh
-  ./uninstall.sh
-  ```
+# Troubleshooting
+
+If you run into other issues with the installation, please [open an issue on our GitHub](https://github.com/jonescompneurolab/hnn/issues). Our team monitors these issues and will be able to suggest possible fixes.
+
+For other HNN software issues, please visit the [HNN bullentin board](https://www.neuron.yale.edu/phpBB/viewforum.php?f=46)

--- a/installer/centos/native_install.md
+++ b/installer/centos/native_install.md
@@ -1,0 +1,23 @@
+# HNN native install (CentOS)
+
+The scripts below can be used to install HNN and its prerequisites. However, there is a greater possibility that your base environment will not be compatible with the script and installation might require additional troubleshooting. Thus, we do not recommend this method. For the recommmeded Docker-based installation, please see the instructions below.
+  - Alternative: [Docker install instructions](README.md)
+
+See the scripts in this directory:
+* CentOS 6: [centos6-installer.sh](centos6-installer.sh)
+* CentOS 7: [centos7-installer.sh](centos7-installer.sh)
+  ```
+  chmod +x ./centos7-installer.sh
+  ./centos7-installer.sh
+  ```
+* [uninstall.sh](uninstall.sh)
+  ```
+  chmod +x ./uninstall.sh
+  ./uninstall.sh
+  ```
+
+# Troubleshooting
+
+If you run into other issues with the installation, please [open an issue on our GitHub](https://github.com/jonescompneurolab/hnn/issues). Our team monitors these issues and will be able to suggest possible fixes.
+
+For other HNN software issues, please visit the [HNN bullentin board](https://www.neuron.yale.edu/phpBB/viewforum.php?f=46)

--- a/installer/mac/README.md
+++ b/installer/mac/README.md
@@ -1,35 +1,37 @@
-# Installing HNN on Mac OS
+# Installing HNN on Mac OS (Docker install)
 
-This guide describes two methods for installing HNN and its prerequisites on Mac OS (tested on High Sierra):
+This guide describes installing HNN on Mac OS using Docker. This method will automatically download the HNN Docker container image when HNN is started for the first time. If you would prefer to install HNN without Docker, please see the instructions below.
+  - Alternative: [Native install instructions (advanced users)](native_install.md)
 
-Method 1: A Docker container running a Linux install of HNN (recommended)
-   - The Docker installation fully isolates HNN's python environment and the NEURON installation from the rest of your system, reducing the possibility of version incompatibilities. Additionally, the same Docker container is used for all platforms (Windows/Linux/Mac) meaning it has likely been tested more recently.
-   
-Method 2: Installing HNN natively on Mac OS (advanced users)
-   - This method will run HNN without using virtualization, meaning the GUI may feel more responsive and simulations may run slightly faster. However, the procedure is a set of steps that the user must follow, and there is a possibility that differences in the base environment may require additional troubleshooting. Thus, Method 2 is best suited for advanced users.
-
-## Method 1: Docker install
-
-[Docker Desktop](https://www.docker.com/products/docker-desktop) requires Mac OS Sierra 10.12 or above. For earlier versions of Mac OS, use the legacy version of [Docker Toolbox](https://docs.docker.com/toolbox/overview/).
-
-The only other prerequisite besides docker is an X server. [XQuartz](https://www.xquartz.org/) is free and the recommended option for Mac OS.
-
-### Prerequisite: install XQuartz
+## Prerequisite: XQuartz
 1. Download the installer image (version 2.7.11 tested): https://www.xquartz.org/
 2. Run the XQuartz.pkg installer within the image, granting privileges when requested.
 3. Start the XQuartz application. An "X" icon will appear in the taskbar along with a terminal, signaling that XQuartz is waiting for connections. You can minimize the terminal, but do not close it.
-4. Open the XQuartz preferences and navigate to the "security" tab. Make sure "Authenticate connections" is unchecked and "Allow connections from network clients" is checked.
+4. **Important** - Open the XQuartz preferences and navigate to the "security" tab. Make sure "Authenticate connections" is unchecked and "Allow connections from network clients" is checked.
 
    <img src="install_pngs/xquartz_preferences.png" height="250" />
 
-### Prerequisite (Mac OS Sierra 10.12 or above): install Docker Desktop
-1. Download the installer image (requires a free Docker Hub account):
-https://hub.docker.com/editions/community/docker-ce-desktop-mac
-2. Run the Docker Desktop installer, moving docker to the applications folder.
-3. Start the Docker application, acknowledging that it was downloaded from the Internet and you still want to open it.
-4. The Docker Desktop icon will appear in the taskbar with the message "Docker Desktop is starting", Followed by "Docker Desktop is running".
+## Prerequisite: Docker
 
-### Prerequisite (Mac OS pre-10.12): install Docker Toolbox
+Click on your version of Mac OS to expand instructions:
+
+<details><summary>10.12 (Sierra) or above: Docker Desktop</summary>
+<p>
+
+1. In order to download Docker Desktop, you'll need to sign up for a Docker Hub account. It only requires an email address to confirm the account. Sign up here: [Docker Hub Sign-up](https://hub.docker.com/signup)
+2. Download the installer image (requires logging in to your Docker Hub account):
+https://hub.docker.com/editions/community/docker-ce-desktop-mac
+3. Run the Docker Desktop installer, moving docker to the applications folder.
+4. Start the Docker application, acknowledging that it was downloaded from the Internet and you still want to open it.
+5. Log into your Docker Hub account if prompted by the Docker Desktop application.
+6. The Docker Desktop icon will appear in the taskbar with the message "Docker Desktop is starting", Followed by "Docker Desktop is running".
+
+</p>
+</details>
+
+<details><summary>Pre 10.12: Docker Toolbox</summary>
+<p>
+
 1. Download the installer image:
 https://docs.docker.com/toolbox/toolbox_install_mac/
 2. Run the installer, selecting any directory for installation.
@@ -46,9 +48,10 @@ https://docs.docker.com/toolbox/toolbox_install_mac/
       ifconfig vboxnet1
       ```
     - Edit the docker-compose.yml file in `hnn/installer/mac/`, replacing `host.docker.internal:0` with the IP address such as `192.168.99.1:0` (**The ":0" is required**). Save the file before running the commands below.
+</p>
+</details>
 
-
-### Start HNN
+## Start HNN
 1. Verify that XQuartz and Docker are running. These will not start automatically after a reboot. Check that Docker is running properly by typing the following in a new terminal window.
     ```
     docker info
@@ -77,307 +80,10 @@ https://docs.docker.com/toolbox/toolbox_install_mac/
 
     If you'd like to be able to copy files from the host OS without using the shared directory, you do so directly with [`docker cp`](https://docs.docker.com/engine/reference/commandline/cp/).
 
-## Method 2: native install
-
-### Prerequisite 1: Xcode Command Line Tools
-
-The Xcode Command Line Tools package includes utilities for compiling code from the terminal window command line (gcc, make, git, etc.). This is needed for compiling mod files in NEURON. To install the package, type the following from a terminal window:
-```
-xcode-select --install
-```
-
-
-### Prerequisite 2: XQuartz
-1. Download the installer image (version 2.7.11 tested): https://www.xquartz.org/
-2. Run the XQuartz.pkg installer within the image, granting privileges when requested.
-3. Start the XQuartz application. An "X" icon will appear in the taskbar along with a terminal, signaling that XQuartz is waiting for connections. You can minimize the terminal, but do not close it.
-
-From the command line:
-```
-cd /tmp/
-curl https://dl.bintray.com/xquartz/downloads/XQuartz-2.7.11.dmg -o XQuartz-2.7.11.dmg
-hdiutil attach /tmp/XQuartz-2.7.11.dmg
-sudo installer -verbose -pkg /Volumes/XQuartz-2.7.11/XQuartz.pkg -target /
-hdiutil detach /Volumes/XQuartz-2.7.11
-rm /tmp/XQuartz-2.7.11.dmg
-open /Applications/Utilities/XQuartz.app
-```
-
-### Prerequisite 3: Miniconda (Python 3)
-
-1. Run the commands below from a terminal window (as a regular user) or download and install miniconda from the link: https://conda.io/en/latest/miniconda.html. This will create a python environment isolated from other installations on the system (e.g. those installed using homebrew). You could use `brew install python3` if you wish (has been tested with HNN), but this guide will cover the miniconda version.
-    ```
-    cd /tmp/
-    curl https://repo.anaconda.com/miniconda/ -o Miniconda3-latest-MacOSX-x86_64.sh
-    sh ./Miniconda3-latest-MacOSX-x86_64.sh -b
-    rm /tmp/Miniconda3-latest-MacOSX-x86_64.sh
-    ```
-
-### Prerequisite 4: NEURON
-
-1. Install [NEURON](https://neuron.yale.edu/neuron/) from the terminal:
-    ```
-    cd /tmp/
-    curl https://neuron.yale.edu/ftp/neuron/versions/v7.6/nrn-7.6.x86_64-osx.pkg -o nrn-7.6.x86_64-osx.pkg
-    sudo installer -verbose -pkg /tmp/nrn-7.6.x86_64-osx.pkg -allowUntrusted -target /
-    ```
-2. You will be asked about setting PATH variable. Say 'No' to both prompts.
-
-  <img src="install_pngs/neuron_path.png" height="250" />
-
-3. Afterward, you will be presented with a confirmation message that NEURON has been installed. Click 'Continue'
-
-  <img src="install_pngs/neuron_continue.png" height="250" />
-
-### Prepare the Python environment
-
-1. Create a conda environment with the Python prerequisites for HNN.
-
-    ```
-    conda create -n hnn mpi4py pyqtgraph pyopengl matplotlib scipy
-    ```
-2. Activate the HNN conda environment
-
-    ```
-    activate hnn
-    ```
-
-3. Set the bash (or other shell) environment variables. Note that depending on your shell (bash or c shell you will use the 4 export commands below or the 4 set commands below, respectively)
-
-  * bash
-
-    Add the following in your ~/.bash_profile (e.g. type "open ~/.bash_profile" in the terminal without the quotes to edit it):
-    ```
-    export PYTHONPATH=/Applications/NEURON-7.6/nrn/lib/python:$PYTHONPATH
-    export PATH=/Applications/NEURON-7.6/nrn/x86_64/bin:$PATH
-    export NRN_PYLIB="~/anaconda3/lib/libpython3.6m.dylib"
-    ```
-  * tcsh
-
-    Add the following in your ~/.cshrc and/or ~/.tcshrc (e.g. type "open ~/.cshrc" or as appropriate in the terminal without the quotes to edit the file):
-    ```
-    set PYTHONPATH=(/Applications/NEURON-7.6/nrn/lib/python $PYTHONPATH)
-    set path = ($path /Applications/NEURON-7.6/nrn/x86_64/bin)
-    set NRN_PYLIB="~/anaconda3/lib/libpython3.6m.dylib" 
-    ```
-
-### Reboot your system
-Please reboot your system before proceeding. A reboot is really needed after installing Xquartz. The environment variables set above will also be set for all terminal windows after the reboot.
-
-### Compile HNN 
-1. After rebooting, open a new terminal and clone the repository:
-    ```
-    git clone https://github.com/jonescompneurolab/hnn.git
-    ```
-2. Now enter the hnn directory and compile HNN's mod files for NEURON. This is where Xcode Command Line Tools are needed.
-    ```
-    cd hnn
-    make
-    ```
-
-### Run the HNN model
-1. Start the HNN GUI from a terminal window:
-    ```
-    conda activate hnn
-    python hnn.py hnn.cfg
-    ```
-2. The HNN GUI should appear and you should now be able to run the tutorials at https://hnn.brown.edu/index.php/tutorials/
-3. When you run simulations for the first time, the following dialog boxes may pop-up and ask you for permission to allow connections through the firewall. Saying 'Deny' is fine since simulations will just run locally on your Mac.
-
-<img src="install_pngs/nrniv_firewall.png" height="250" />
-<img src="install_pngs/orterun_firewall.png" height="250" />
-
 # Troubleshooting
 
-## Method 1 (docker install)
-Please see the [Docker troubleshooting section](../docker/README.md#Troubleshooting)
+For Mac OS specific issues: please see the [Mac OS troubleshooting page](troubleshooting.md)
 
-## Method 2 (native install)
+If you run into other issues with the installation, please [open an issue on our GitHub](https://github.com/jonescompneurolab/hnn/issues). Our team monitors these issues and will be able to suggest possible fixes.
 
-### Error message: `There are not enough slots available in the system`
-
-The message on the console from mpiexec looks something like:
-```
-Starting simulation. . .
---------------------------------------------------------------------------
-There are not enough slots available in the system to satisfy the 8 slots
-that were requested by the application:
-  nrniv
-
-Either request fewer slots for your application or make more slots available
-for use.
---------------------------------------------------------------------------
-```
-
-This may happen when there is a discrepancy in how many cores HNN attempts to use (all available by default) and how many cores are available to MPI. This may be because of restrictions on user resource usage on batch/HPC cluster environments or particular versions of MPI (e.g. homebrew open-mpi) that don't count cores turned on by the processor's hyperthreading feature. Try reducing the number of cores in the HNN GUI under 'Set parameters' -> 'Run' by half.
-
-### Error message: `ls: /usr/local/bin/../lib/libpython*.dylib: No such file or directory`
-
-This error message may appear when running simulations and is more likely to appear if a different python is used than Anaconda or Miniconda. One such case is when python3 is installed using homebrew `brew install python3`. In this case, PYTHONHOME needs to be specified in addition to NRN_PYLIB. An example is below. Verify the paths that exist on your system and use them in place of the paths below.
-  ```
-  export NRN_PYLIB="/usr/local/Cellar/python3/3.7.2_2/Frameworks/Python.framework/Versions/3.7/lib/libpython3.7m.dylib"
-  export PYTHONHOME="/usr/local/Cellar/python/3.7.2_2/Frameworks/Python.framework/Versions/3.7/"
-  ```
-
-### Error message: `Error: Cannot allocate memory. Check the CQE attribute`
-
-This message gets printed to the command line from mpiexec:
-```
-Starting simulation. . .
---------------------------------------------------------------------------
-Failed to create a completion queue (CQ):
-
-Hostname: node423
-Requested CQE: 16384
-Error:    Cannot allocate memory
-
-Check the CQE attribute
---------------------------------------------------------------------------
-```
-
-One possible fix to this may be increasing the maximum locked memory a user is able to allocate using
-```
-ulimit -l unlimited
-```
-This may not be allowed for a non-privileged user, such as on a batch or HPC environment. Check with the system administrator if you get an error message running this command.
-
-### Simulation log says "X total processes failed to start"
-Check the command line output where "`python hnn.py hnn.cfg`" was run. If you get a message like the following, then your PATH environment variable needs to be updated to include the NEURON binaries, like `nrniv`
-```
-Starting simulation. . .
---------------------------------------------------------------------------
-mpiexec was unable to launch the specified application as it could not find an executable:
-
-Executable: nrniv
-Node: My-MacBook-Pro.local
-
-while attempting to start process rank 0.
---------------------------------------------------------------------------
-```
-Try running `nrniv` from the command line. If you get a message like `-bash: nrniv: command not found`, add the directory containing `nrniv` to the PATH environment variable. If this fixed the problem, you will need to add the export or set (for tcsh) command to your .bashrc or .csh/.tcsh file so that it works for every terminal window.
-```
-$ export PATH=/Applications/NEURON-7.6/nrn/x86_64/bin:$PATH
-$ nrniv
-NEURON -- VERSION 7.6.5 master (f3dad62b) 2019-01-11
-Duke, Yale, and the BlueBrain Project -- Copyright 1984-2018
-See http://neuron.yale.edu/neuron/credits
-
-loading membrane mechanisms from x86_64/.libs/libnrnmech.so
-Additional mechanisms from files
- mod/ar.mod mod/beforestep_py.mod mod/ca.mod mod/cad.mod mod/cat.mod mod/dipole.mod mod/dipole_pp.mod mod/hh2.mod mod/kca.mod mod/km.mod mod/lfp.mod mod/mea.mod mod/vecevent.mod
-oc>
-```
-
-
-### Stream of error messages from MPI
-
-When running an HNN simulation, you may get a message back immediately from HNN that all simulations have finished, but with a stream of error messages in the terminal window and no results in the GUI.
-
-Some examples of the error messages:
-
-```
-OPAL ERROR: Not initialized in file pmix3x_client.c at line 113
-```
-  * Since OPAL is a part of MPI, you can reason that this is a problem when NEURON tries to call mpiexec.
-```
-Local abort before MPI_INIT completed successfully
-```
-```
---------------------------------------------------------------------------
-mpiexec noticed that the job aborted, but has no info as to the process
-that caused that situation.
---------------------------------------------------------------------------
-```
-  * These are standard error messages that openmpi produces when there's an error on one process. Since we are running an openmpi process for each core that HNN runs on, these messages will be repeated.
-
-#### MPI debugging, step 1: is NEURON the problem (part 1)?
-
-To remove NEURON from the list of possible problems, try running `nrniv -nopython` from the command line. You should get a `oc>` prompt when there are no problems.
-
-#### MPI debugging, step 2: Is Python the problem?
-
-As a simple debugging step, make sure that NEURON can load the necessary python libraries:
-```
-$ nrniv -python
-NEURON -- VERSION 7.6.5 master (f3dad62b) 2019-01-11
-Duke, Yale, and the BlueBrain Project -- Copyright 1984-2018
-See http://neuron.yale.edu/neuron/credits
-
-loading membrane mechanisms from x86_64/.libs/libnrnmech.so
-Additional mechanisms from files
- mod/ar.mod mod/beforestep_py.mod mod/ca.mod mod/cad.mod mod/cat.mod mod/dipole.mod mod/dipole_pp.mod mod/hh2.mod mod/kca.mod mod/km.mod mod/lfp.mod mod/mea.mod mod/vecevent.mod
->>> 
-```
-Exit the prompt by typing `quit()`.  If you didn't get any errors, then proceed to the next troubleshooting step. If you get the following error about "No module named 'encodings'", then the problem has to do with environment variables.
-```
-$ nrniv -python
-NEURON -- VERSION 7.6.5 master (f3dad62b) 2019-01-11
-Duke, Yale, and the BlueBrain Project -- Copyright 1984-2018
-See http://neuron.yale.edu/neuron/credits
-
-loading membrane mechanisms from x86_64/.libs/libnrnmech.so
-Additional mechanisms from files
- mod/ar.mod mod/beforestep_py.mod mod/ca.mod mod/cad.mod mod/cat.mod mod/dipole.mod mod/dipole_pp.mod mod/hh2.mod mod/kca.mod mod/km.mod mod/lfp.mod mod/mea.mod mod/vecevent.mod
-Fatal Python error: initfsencoding: unable to load the file system codec
-ModuleNotFoundError: No module named 'encodings'
-
-Current thread 0x000000010a2e45c0 (most recent call first):
-Abort trap: 6
-```
-
-This message about 'encodings' means that NEURON is unable to load default python libraries, despite being able to start python. Note these are core libraries, not a package that needs to be installed. So we should be able to fix the problem with environment variables. Start by changing one at a time and re-running `nrniv -python`. If you get the '>>>' prompt, move on to the next step.
- * PYTHONHOME: You shouldn't need to set this because it will often be determined by the location of the python binary used. However, if it is set to an invalid value, then `nrniv -python` will fail. Try unsetting it:
-   ```
-   unset PYTHONHOME
-   ```
-   If you are still having problems, set PYTHONHOME to the python installation directory that is the parent to all of the directories bin, lib, doc, and etc.
-
- * NRN_PYLIB: this may not need to be set. Try unsetting it:
-   ```
-   unset NRN_PYLIB
-   ```
-   If it must be set, make sure that it points to a valid .dylib file that matches the python binary you are using (i.e. don't mix and match anaconda python with a homebrew dylib)
-   - conda: `export NRN_PYLIB=~/miniconda3/envs/hnn/lib/libpython3.6m.dylib`
-   - homebrew: `export NRN_PYLIB="/usr/local/Cellar/python3/3.7.2_2/Frameworks/Python.framework/Versions/3.7/lib/libpython3.7m.dylib"`
-
-#### MPI debugging, step 3: is NEURON the problem (part 2)?
-
-Based on the previous step, we know that `nrniv` can start python, but this step checks if python can load neuron libraries, By importing the neuron module into python, you should get something similar to the below:
-```
-$ python 
-Python 3.6.8 |Anaconda, Inc.| (default, Dec 29 2018, 19:04:46) 
-[GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)] on darwin
-Type "help", "copyright", "credits" or "license" for more information.
->>> import neuron
->>>
-```
-Quit by typing `quit()`. If instead of the above, you get an error similar to below,
-```
->>> import neuron
-Traceback (most recent call last):
-  File "<stdin>", line 1, in <module>
-ModuleNotFoundError: No module named 'neuron'
->>> quit
-```
-Then the environment variable PYTHONPATH needs to be set
- * PYTHONPATH: this should include the path to NEURON libraries. Make sure the path is valid (e.g. /Applications/NEURON-7.6/nrn/lib/python). The environment variable may include multiple entries (others that are related to NEURON).
-
-#### MPI debugging, step 4: is MPI the problem?
-
-If conda or pip was able to install mpi4py, then mpiexec (as part of openmpi) should be on your system. Make sure that it can be found from your PATH. To test running two MPI processes in parallel:
-```
-$ mpiexec -n 2 hostname
-My-MacBook-Pro.local
-My-MacBook-Pro.local
-```
-If there are no errors, then return to HNN and try to run a simulation.
-
-If you receive the error
-```
-dyld: Library not loaded: @rpath/libmpi.1.dylib
-```
-You will need to specify the environment variable LD_LIBRARY_PATH similar to below, and add the command below to your `~/.bashrc` file (or tcsh equivalent) so that it gets set in every subsequent terminal session.
-```
-export LD_LIBRARY_PATH=~/miniconda3/envs/hnn/lib
-```
-
+For other HNN software issues, please visit the [HNN bullentin board](https://www.neuron.yale.edu/phpBB/viewforum.php?f=46)

--- a/installer/mac/native_install.md
+++ b/installer/mac/native_install.md
@@ -1,0 +1,120 @@
+# HNN native install (Mac OS)
+
+This method will run HNN without using virtualization, meaning the GUI may feel more responsive and simulations may run slightly faster. However, the procedure is a set of steps that the user must follow, and there is a possibility that differences in the base environment may require additional troubleshooting. Thus, it is best suited for advanced users. For the recommended Docker-based installation please see the instructions below.
+  - Alternative: [Docker install instructions](README.md)
+
+## Prerequisite 1: Xcode Command Line Tools
+
+The Xcode Command Line Tools package includes utilities for compiling code from the terminal window command line (gcc, make, git, etc.). This is needed for compiling mod files in NEURON. To install the package, type the following from a terminal window:
+```
+xcode-select --install
+```
+
+
+## Prerequisite 2: XQuartz
+1. Download the installer image (version 2.7.11 tested): https://www.xquartz.org/
+2. Run the XQuartz.pkg installer within the image, granting privileges when requested.
+3. Start the XQuartz application. An "X" icon will appear in the taskbar along with a terminal, signaling that XQuartz is waiting for connections. You can minimize the terminal, but do not close it.
+
+From the command line:
+```
+cd /tmp/
+curl https://dl.bintray.com/xquartz/downloads/XQuartz-2.7.11.dmg -o XQuartz-2.7.11.dmg
+hdiutil attach /tmp/XQuartz-2.7.11.dmg
+sudo installer -verbose -pkg /Volumes/XQuartz-2.7.11/XQuartz.pkg -target /
+hdiutil detach /Volumes/XQuartz-2.7.11
+rm /tmp/XQuartz-2.7.11.dmg
+open /Applications/Utilities/XQuartz.app
+```
+
+## Prerequisite 3: Miniconda (Python 3)
+
+1. Run the commands below from a terminal window (as a regular user) or download and install miniconda from the link: https://conda.io/en/latest/miniconda.html. This will create a python environment isolated from other installations on the system (e.g. those installed using homebrew). You could use `brew install python3` if you wish (has been tested with HNN), but this guide will cover the miniconda version.
+    ```
+    cd /tmp/
+    curl https://repo.anaconda.com/miniconda/ -o Miniconda3-latest-MacOSX-x86_64.sh
+    sh ./Miniconda3-latest-MacOSX-x86_64.sh -b
+    rm /tmp/Miniconda3-latest-MacOSX-x86_64.sh
+    ```
+
+## Prerequisite 4: NEURON
+
+1. Install [NEURON](https://neuron.yale.edu/neuron/) from the terminal:
+    ```
+    cd /tmp/
+    curl https://neuron.yale.edu/ftp/neuron/versions/v7.6/nrn-7.6.x86_64-osx.pkg -o nrn-7.6.x86_64-osx.pkg
+    sudo installer -verbose -pkg /tmp/nrn-7.6.x86_64-osx.pkg -allowUntrusted -target /
+    ```
+2. You will be asked about setting PATH variable. Say 'No' to both prompts.
+
+  <img src="install_pngs/neuron_path.png" height="250" />
+
+3. Afterward, you will be presented with a confirmation message that NEURON has been installed. Click 'Continue'
+
+  <img src="install_pngs/neuron_continue.png" height="250" />
+
+## Prepare the Python environment
+
+1. Create a conda environment with the Python prerequisites for HNN.
+
+    ```
+    conda create -n hnn mpi4py pyqtgraph pyopengl matplotlib scipy
+    ```
+2. Activate the HNN conda environment
+
+    ```
+    activate hnn
+    ```
+
+3. Set the bash (or other shell) environment variables. Note that depending on your shell (bash or c shell you will use the 4 export commands below or the 4 set commands below, respectively)
+
+  * bash
+
+    Add the following in your ~/.bash_profile (e.g. type "open ~/.bash_profile" in the terminal without the quotes to edit it):
+    ```
+    export PYTHONPATH=/Applications/NEURON-7.6/nrn/lib/python:$PYTHONPATH
+    export PATH=/Applications/NEURON-7.6/nrn/x86_64/bin:$PATH
+    export NRN_PYLIB="~/anaconda3/lib/libpython3.6m.dylib"
+    ```
+  * tcsh
+
+    Add the following in your ~/.cshrc and/or ~/.tcshrc (e.g. type "open ~/.cshrc" or as appropriate in the terminal without the quotes to edit the file):
+    ```
+    set PYTHONPATH=(/Applications/NEURON-7.6/nrn/lib/python $PYTHONPATH)
+    set path = ($path /Applications/NEURON-7.6/nrn/x86_64/bin)
+    set NRN_PYLIB="~/anaconda3/lib/libpython3.6m.dylib"
+    ```
+
+## Reboot your system
+Please reboot your system before proceeding. A reboot is really needed after installing Xquartz. The environment variables set above will also be set for all terminal windows after the reboot.
+
+## Compile HNN
+1. After rebooting, open a new terminal and clone the repository:
+    ```
+    git clone https://github.com/jonescompneurolab/hnn.git
+    ```
+2. Now enter the hnn directory and compile HNN's mod files for NEURON. This is where Xcode Command Line Tools are needed.
+    ```
+    cd hnn
+    make
+    ```
+
+## Run the HNN model
+1. Start the HNN GUI from a terminal window:
+    ```
+    conda activate hnn
+    python hnn.py hnn.cfg
+    ```
+2. The HNN GUI should appear and you should now be able to run the tutorials at https://hnn.brown.edu/index.php/tutorials/
+3. When you run simulations for the first time, the following dialog boxes may pop-up and ask you for permission to allow connections through the firewall. Saying 'Deny' is fine since simulations will just run locally on your Mac.
+
+<img src="install_pngs/nrniv_firewall.png" height="250" />
+<img src="install_pngs/orterun_firewall.png" height="250" />
+
+# Troubleshooting
+
+For Mac OS specific issues: please see the [Mac OS troubleshooting page](troubleshooting.md)
+
+If you run into other issues with the installation, please [open an issue on our GitHub](https://github.com/jonescompneurolab/hnn/issues). Our team monitors these issues and will investigate possible fixes.
+
+For other HNN software issues, please visit the [HNN bullentin board](https://www.neuron.yale.edu/phpBB/viewforum.php?f=46)

--- a/installer/mac/troubleshooting.md
+++ b/installer/mac/troubleshooting.md
@@ -1,0 +1,192 @@
+# Troubleshooting on Mac OS
+
+## Docker
+For errors related to installing docker, please see the [Docker troubleshooting section](../docker/README.md#Troubleshooting)
+
+## Error message: `There are not enough slots available in the system`
+
+The message on the console from mpiexec looks something like:
+```
+Starting simulation. . .
+--------------------------------------------------------------------------
+There are not enough slots available in the system to satisfy the 8 slots
+that were requested by the application:
+  nrniv
+
+Either request fewer slots for your application or make more slots available
+for use.
+--------------------------------------------------------------------------
+```
+
+This may happen when there is a discrepancy in how many cores HNN attempts to use (all available by default) and how many cores are available to MPI. This may be because of restrictions on user resource usage on batch/HPC cluster environments or particular versions of MPI (e.g. homebrew open-mpi) that don't count cores turned on by the processor's hyperthreading feature. Try reducing the number of cores in the HNN GUI under 'Set Parameters' -> 'Run' by half.
+
+## Error message: `ls: /usr/local/bin/../lib/libpython*.dylib: No such file or directory`
+
+This error message may appear when running simulations and is more likely to appear if a different python is used than Anaconda or Miniconda. One such case is when python3 is installed using homebrew `brew install python3`. In this case, PYTHONHOME needs to be specified in addition to NRN_PYLIB. An example is below. Verify the paths that exist on your system and use them in place of the paths below.
+  ```
+  export NRN_PYLIB="/usr/local/Cellar/python3/3.7.2_2/Frameworks/Python.framework/Versions/3.7/lib/libpython3.7m.dylib"
+  export PYTHONHOME="/usr/local/Cellar/python/3.7.2_2/Frameworks/Python.framework/Versions/3.7/"
+  ```
+
+## Error message: `Error: Cannot allocate memory. Check the CQE attribute`
+
+This message gets printed to the command line from mpiexec:
+```
+Starting simulation. . .
+--------------------------------------------------------------------------
+Failed to create a completion queue (CQ):
+
+Hostname: node423
+Requested CQE: 16384
+Error:    Cannot allocate memory
+
+Check the CQE attribute
+--------------------------------------------------------------------------
+```
+
+One possible fix to this may be increasing the maximum locked memory a user is able to allocate using
+```
+ulimit -l unlimited
+```
+This may not be allowed for a non-privileged user, such as on a batch or HPC environment. Check with the system administrator if you get an error message running this command.
+
+## Simulation log says "X total processes failed to start"
+Check the command line output where "`python hnn.py hnn.cfg`" was run. If you get a message like the following, then your PATH environment variable needs to be updated to include the NEURON binaries, like `nrniv`
+```
+Starting simulation. . .
+--------------------------------------------------------------------------
+mpiexec was unable to launch the specified application as it could not find an executable:
+
+Executable: nrniv
+Node: My-MacBook-Pro.local
+
+while attempting to start process rank 0.
+--------------------------------------------------------------------------
+```
+Try running `nrniv` from the command line. If you get a message like `-bash: nrniv: command not found`, add the directory containing `nrniv` to the PATH environment variable. If this fixed the problem, you will need to add the export or set (for tcsh) command to your .bashrc or .csh/.tcsh file so that it works for every terminal window.
+```
+$ export PATH=/Applications/NEURON-7.6/nrn/x86_64/bin:$PATH
+$ nrniv
+NEURON -- VERSION 7.6.5 master (f3dad62b) 2019-01-11
+Duke, Yale, and the BlueBrain Project -- Copyright 1984-2018
+See http://neuron.yale.edu/neuron/credits
+
+loading membrane mechanisms from x86_64/.libs/libnrnmech.so
+Additional mechanisms from files
+ mod/ar.mod mod/beforestep_py.mod mod/ca.mod mod/cad.mod mod/cat.mod mod/dipole.mod mod/dipole_pp.mod mod/hh2.mod mod/kca.mod mod/km.mod mod/lfp.mod mod/mea.mod mod/vecevent.mod
+oc>
+```
+
+
+## Stream of error messages from MPI
+
+When running an HNN simulation, you may get a message back immediately from HNN that all simulations have finished, but with a stream of error messages in the terminal window and no results in the GUI.
+
+Some examples of the error messages:
+
+```
+OPAL ERROR: Not initialized in file pmix3x_client.c at line 113
+```
+  * Since OPAL is a part of MPI, you can reason that this is a problem when NEURON tries to call mpiexec.
+```
+Local abort before MPI_INIT completed successfully
+```
+```
+--------------------------------------------------------------------------
+mpiexec noticed that the job aborted, but has no info as to the process
+that caused that situation.
+--------------------------------------------------------------------------
+```
+  * These are standard error messages that openmpi produces when there's an error on one process. Since we are running an openmpi process for each core that HNN runs on, these messages will be repeated.
+
+### MPI debugging, step 1: is NEURON the problem (part 1)?
+
+To remove NEURON from the list of possible problems, try running `nrniv -nopython` from the command line. You should get a `oc>` prompt when there are no problems.
+
+### MPI debugging, step 2: Is Python the problem?
+
+As a simple debugging step, make sure that NEURON can load the necessary python libraries:
+```
+$ nrniv -python
+NEURON -- VERSION 7.6.5 master (f3dad62b) 2019-01-11
+Duke, Yale, and the BlueBrain Project -- Copyright 1984-2018
+See http://neuron.yale.edu/neuron/credits
+
+loading membrane mechanisms from x86_64/.libs/libnrnmech.so
+Additional mechanisms from files
+ mod/ar.mod mod/beforestep_py.mod mod/ca.mod mod/cad.mod mod/cat.mod mod/dipole.mod mod/dipole_pp.mod mod/hh2.mod mod/kca.mod mod/km.mod mod/lfp.mod mod/mea.mod mod/vecevent.mod
+>>>
+```
+Exit the prompt by typing `quit()`.  If you didn't get any errors, then proceed to the next troubleshooting step. If you get the following error about "No module named 'encodings'", then the problem has to do with environment variables.
+```
+$ nrniv -python
+NEURON -- VERSION 7.6.5 master (f3dad62b) 2019-01-11
+Duke, Yale, and the BlueBrain Project -- Copyright 1984-2018
+See http://neuron.yale.edu/neuron/credits
+
+loading membrane mechanisms from x86_64/.libs/libnrnmech.so
+Additional mechanisms from files
+ mod/ar.mod mod/beforestep_py.mod mod/ca.mod mod/cad.mod mod/cat.mod mod/dipole.mod mod/dipole_pp.mod mod/hh2.mod mod/kca.mod mod/km.mod mod/lfp.mod mod/mea.mod mod/vecevent.mod
+Fatal Python error: initfsencoding: unable to load the file system codec
+ModuleNotFoundError: No module named 'encodings'
+
+Current thread 0x000000010a2e45c0 (most recent call first):
+Abort trap: 6
+```
+
+This message about 'encodings' means that NEURON is unable to load default python libraries, despite being able to start python. Note these are core libraries, not a package that needs to be installed. So we should be able to fix the problem with environment variables. Start by changing one at a time and re-running `nrniv -python`. If you get the '>>>' prompt, move on to the next step.
+ * PYTHONHOME: You shouldn't need to set this because it will often be determined by the location of the python binary used. However, if it is set to an invalid value, then `nrniv -python` will fail. Try unsetting it:
+   ```
+   unset PYTHONHOME
+   ```
+   If you are still having problems, set PYTHONHOME to the python installation directory that is the parent to all of the directories bin, lib, doc, and etc.
+
+ * NRN_PYLIB: this may not need to be set. Try unsetting it:
+   ```
+   unset NRN_PYLIB
+   ```
+   If it must be set, make sure that it points to a valid .dylib file that matches the python binary you are using (i.e. don't mix and match anaconda python with a homebrew dylib)
+   - conda: `export NRN_PYLIB=~/miniconda3/envs/hnn/lib/libpython3.6m.dylib`
+   - homebrew: `export NRN_PYLIB="/usr/local/Cellar/python3/3.7.2_2/Frameworks/Python.framework/Versions/3.7/lib/libpython3.7m.dylib"`
+
+### MPI debugging, step 3: is NEURON the problem (part 2)?
+
+Based on the previous step, we know that `nrniv` can start python, but this step checks if python can load neuron libraries, By importing the neuron module into python, you should get something similar to the below:
+```
+$ python 
+Python 3.6.8 |Anaconda, Inc.| (default, Dec 29 2018, 19:04:46) 
+[GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)] on darwin
+Type "help", "copyright", "credits" or "license" for more information.
+>>> import neuron
+>>>
+```
+Quit by typing `quit()`. If instead of the above, you get an error similar to below,
+```
+>>> import neuron
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+ModuleNotFoundError: No module named 'neuron'
+>>> quit
+```
+Then the environment variable PYTHONPATH needs to be set
+ * PYTHONPATH: this should include the path to NEURON libraries. Make sure the path is valid (e.g. /Applications/NEURON-7.6/nrn/lib/python). The environment variable may include multiple entries (others that are related to NEURON).
+
+### MPI debugging, step 4: is MPI the problem?
+
+If conda or pip was able to install mpi4py, then mpiexec (as part of openmpi) should be on your system. Make sure that it can be found from your PATH. To test running two MPI processes in parallel:
+```
+$ mpiexec -n 2 hostname
+My-MacBook-Pro.local
+My-MacBook-Pro.local
+```
+If there are no errors, then return to HNN and try to run a simulation.
+
+If you receive the error
+```
+dyld: Library not loaded: @rpath/libmpi.1.dylib
+```
+You will need to specify the environment variable LD_LIBRARY_PATH similar to below, and add the command below to your `~/.bashrc` file (or tcsh equivalent) so that it gets set in every subsequent terminal session.
+```
+export LD_LIBRARY_PATH=~/miniconda3/envs/hnn/lib
+```
+

--- a/installer/ubuntu/README.md
+++ b/installer/ubuntu/README.md
@@ -1,15 +1,10 @@
-# Installing HNN on Ubuntu
+# Installing HNN on Ubuntu (Docker install)
 
-This guide describes two methods for installing HNN and its prerequisites Ubuntu (tested on Ubuntu 18.04 LTS):
+This guide describes installing HNN on Ubuntu using Docker. This method will automatically download the HNN Docker container image when HNN is started for the first time. If you would prefer to install HNN without Docker, please see the instructions below.
+  - Alternative: [Native install instructions (advanced users)](native_install.md)
 
-Method 1: A Docker container running a Linux install of HNN (recommended)
-   - The Docker installation fully isolates HNN's python environment and the NEURON installation from the rest of your system, reducing the possibility of version incompatibilities. Additionally, the same Docker container is used for all platforms (Windows/Linux/Mac) meaning it has likely been tested more recently.
+**Note: please verify your OS supports Docker CE**
    - See [OS requirements](https://docs.docker.com/install/linux/docker-ce/ubuntu/#os-requirements)
-
-Method 2: Natively running HNN on Ubuntu (advanced users)
-   - HNN runs directly on the OS and uses a script to download and install prerequisites. It is more difficult to control the native environment than in Method 1 (with Docker), so it's possible that the script will need user intervention. Thus, Method 2 is best suited for advanced users.
-
-## Method 1: Docker install
 
 ### Prerequisite: install Docker
 * Follow [Docker's Ubuntu install instructions](https://docs.docker.com/install/linux/docker-ce/ubuntu/) to install the docker-ce packages from Docker's official repository
@@ -56,20 +51,8 @@ Method 2: Natively running HNN on Ubuntu (advanced users)
 
     If you'd like to be able to copy files from the host OS without using the shared directory, you do so directly with [`docker cp`](https://docs.docker.com/engine/reference/commandline/cp/).
 
-## Method 2: native install
-See the scripts in this directory:
-* [installer.sh](installer.sh)
-  ```
-  chmod +x ./installer.sh
-  ./installer.sh
-  ```
-* [uninstaller.sh](uninstaller.sh)
-  ```
-  chmod +x ./uninstaller.sh
-  ./uninstaller.sh
-  ```
-* [updater.sh](updater.sh)
-  ```
-  chmod +x ./updater.sh
-  ./updater.sh
-  ```
+# Troubleshooting
+
+If you run into other issues with the installation, please [open an issue on our GitHub](https://github.com/jonescompneurolab/hnn/issues). Our team monitors these issues and will be able to suggest possible fixes.
+
+For other HNN software issues, please visit the [HNN bullentin board](https://www.neuron.yale.edu/phpBB/viewforum.php?f=46)

--- a/installer/ubuntu/native_install.md
+++ b/installer/ubuntu/native_install.md
@@ -1,0 +1,27 @@
+# HNN native install (Ubuntu)
+
+The scripts below can be used to install HNN and its prerequisites. However, there is a greater possibility that your base environment will not be compatible with the script and installation might require additional troubleshooting. Thus, we do not recommend this method. For the recommmeded Docker-based installation, please see the instructions below.
+  - Alternative: [Docker install instructions](README.md)
+
+See the scripts in this directory:
+* [installer.sh](installer.sh)
+  ```
+  chmod +x ./installer.sh
+  ./installer.sh
+  ```
+* [uninstaller.sh](uninstaller.sh)
+  ```
+  chmod +x ./uninstaller.sh
+  ./uninstaller.sh
+  ```
+* [updater.sh](updater.sh)
+  ```
+  chmod +x ./updater.sh
+  ./updater.sh
+  ```
+
+# Troubleshooting
+
+If you run into other issues with the installation, please [open an issue on our GitHub](https://github.com/jonescompneurolab/hnn/issues). Our team monitors these issues and will be able to suggest possible fixes.
+
+For other HNN software issues, please visit the [HNN bullentin board](https://www.neuron.yale.edu/phpBB/viewforum.php?f=46)

--- a/installer/windows/README.md
+++ b/installer/windows/README.md
@@ -1,29 +1,19 @@
-# Installing HNN on Windows systems
+# Installing HNN on Windows (Docker install)
 
-This guide describes two methods for installing HNN and its prerequisites on a Windows 10 system:
+This guide describes installing HNN on Windows 10 using Docker. This method will automatically download the HNN Docker container image when HNN is started for the first time. If you would prefer to install HNN without Docker, please see the instructions below.
+  - Alternative: [Native install instructions (advanced users)](native_install.md)
 
-Method 1: A Docker container running a Linux install of HNN (recommended)
-   - The Docker installation fully isolates HNN's python environment and the NEURON installation from the rest of your system, reducing the possibility of version incompatibilities. Additionally, the same Docker container is used for all platforms (Windows/Linux/Mac) meaning it has likely been tested more recently.
-
-Method 2: Running a script to install HNN natively on Windows (advanced users)
-   - A script will download and install prerequisites without using virtualization, meaning the GUI may feel more responsive and simulations may run slightly faster. The script will detect installed Python environments, and install the HNN prerequisites in an isolated environment using conda or virtualenv. It is safe to run the script multiple times.
-
-**Note (only for method 1):**  the Hyper-V feature must be enabled on your computer to use the Docker-based installation. Not all systems support this feature, and it may require making changes to your computer's BIOS settings. You can check whether it is enabled with the following procedure.
+## Prerequisite: Hyper-V support
+The Hyper-V feature must be enabled on your computer to use the Docker-based installation. Not all systems support this feature, and it may require making changes to your computer's BIOS settings. If you run into problems enabling Hyper-V, we recommend that you follow the [native install instructions](native_install.md) instead. You can check whether it is enabled with the following procedure.
 
 1. Open the Control Panel "Turn Windows features on or off" (search bar next to start menu).
 2. Make sure that Hyper-V is turned on as in the image below
 
     <img src="install_pngs/hyper-V.png" height="200" />
 
-3. If Hyper-V was disabled, please reboot your computer before continuing below to install docker.
+3. If you enabled Hyper-V, please reboot your computer before continuing below to install docker.
 
-## Method 1: Docker install
-
-[Docker Desktop](https://www.docker.com/products/docker-desktop) for Windows 10 (Pro/Enterprise only) is capable of running both Linux containers and Windows containers. For HNN's GUI to display properly, only Linux containers work. Docker Desktop is installed with this configuration by default.  For Windows 10 Home or other versions of windows, use the legacy version of [Docker Toolbox](https://docs.docker.com/toolbox/overview/).
-
-The only other component to install is an X server. Both [VcXsrv](https://sourceforge.net/projects/vcxsrv/) and [Xming](https://sourceforge.net/projects/xming/) are recommended free options. These install instructions will cover VcXsrv.
-
-### Prerequisite: install VcXsrv
+## Prerequisite: VcXsrv
 1. Download the installer (version 64.1.20.1.4 tested): https://sourceforge.net/projects/vcxsrv/files/latest/download
    * [Alternative direct download link](https://downloads.sourceforge.net/project/vcxsrv/vcxsrv/1.20.1.4/vcxsrv-64.1.20.1.4.installer.exe?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fvcxsrv%2Ffiles%2Fvcxsrv%2F1.20.1.4%2Fvcxsrv-64.1.20.1.4.installer.exe%2Fdownload%3Fuse_mirror%3Dversaweb%26r%3Dhttps%253A%252F%252Fsourceforge.net%252Fprojects%252Fvcxsrv%252Ffiles%252Flatest%252Fdownload&ts=1550243133)
 2. Run the installer, choosing any installation folder.
@@ -34,13 +24,18 @@ The only other component to install is an X server. Both [VcXsrv](https://source
 7. Click "Finish" and an "X" icon will appear in the lower-right dock signaling that VcXsrv is waiting for connections.
 8. A message from Windows firewall to allow connections may pop up. If it does, choose options allowing connections to the VcXsrv when connected to both public and private networks.
 
+## Prerequisite: Docker
 
-### Prerequisite (Windows 10 Pro/Enterprise): install Docker Desktop
-1. Download the installer (requires a free Docker Hub account):
+Click on your version of Windows to expand instructions:
+<details><summary>Windows 10 (Pro/Enterprise only): Docker Desktop</summary>
+<p>
+
+1. In order to download Docker Desktop, you'll need to sign up for a Docker Hub account. It only requires an email address to confirm the account. Sign up here: [Docker Hub Sign-up](https://hub.docker.com/signup)
+2. Download the installer (requires logging in to your Docker Hub account):
 https://hub.docker.com/editions/community/docker-ce-desktop-windows
-2. Run the installer. **DO NOT check** "Use Windows containers instead of Linux containers".
-3. Start the Docker Desktop app from the start menu.
-4. The installer may prompt you to turn on Hyper-V, which will not allow you to also run virtual machines through applications such as VirtualBox. If you get an error saying that Hyper-V needs to be enabled, you can do it manually by "Control Panel" -> Programs -> "Turn Windows features on or off" and select all Hyper-V options (a reboot is required).
+3. Run the installer. **DO NOT check** "Use Windows containers instead of Linux containers".
+4. Start the Docker Desktop app from the start menu (requires logging in to your Docker Hub account).
+5. The installer may prompt you to turn on Hyper-V, which will not allow you to also run virtual machines through applications such as VirtualBox. If you get an error saying that Hyper-V needs to be enabled, you can do it manually by "Control Panel" -> Programs -> "Turn Windows features on or off" and select all Hyper-V options (a reboot is required).
    * If you get a message similar to the screen below, click 'Ok' and restart your computer.
      <img src="install_pngs/enable_hyperv.png" height="150" />
 
@@ -49,7 +44,12 @@ https://hub.docker.com/editions/community/docker-ce-desktop-windows
 
      <img src="install_pngs/hyperv_error.png" height="150" />
 
-### Prerequisite (Windows 10 Home only): install Docker Toolbox
+</p>
+</details>
+
+<details><summary>Windows 10 Home: Docker Toolbox</summary>
+<p>
+
 1. Download the installer:
 https://docs.docker.com/toolbox/toolbox_install_windows/
 2. Run the installer. In "Select Components" check the component "Docker Compose for Windows". Click 'Next'.
@@ -58,7 +58,10 @@ https://docs.docker.com/toolbox/toolbox_install_windows/
 5. Launch "Docker Quickstart Terminal" from the Desktop or start menu.
 6. Run the commands below from a new cmd.exe window.
 
-### Start HNN
+</p>
+</details>
+
+## Start HNN
 1. Verify that VcXsrv (XLaunch application) and Docker are running. These will not start automatically after a reboot. Check that Docker is running properly by typing the following in a new cmd.exe window.
     ```
     docker info
@@ -89,41 +92,8 @@ https://docs.docker.com/toolbox/toolbox_install_windows/
 
     If you'd like to be able to copy files from the host OS without using the shared directory, you do so directly with [`docker cp`](https://docs.docker.com/engine/reference/commandline/cp/).
 
-## Method 2: native install script
+# Troubleshooting
 
-The [HNN install PowerShell script](hnn.ps1) will manage downloading all prerequisites except Microsoft MPI which requires a web browser to download. If the script finds msmpisetup.exe in the Downloads folder, it will take care of installing it.
+If you run into other issues with the installation, please [open an issue on our GitHub](https://github.com/jonescompneurolab/hnn/issues). Our team monitors these issues and will be able to suggest possible fixes.
 
-Requirements:
- - A 64-bit OS
- - Windows 7 or later. Windows Vista is not supported for lack of multiprocessing support.
- - PowerShell version 1.0 or later. If PowerShell is not installed, please follow the link below for downloading and running the PowerShell installer:
- https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell
-
-Install procedure:
-1. Download Microsoft MPI (msmpisetup.exe) from the link below and save it to the user's Downloads  folder (C:\Users\\[MY_USERNAME]\Downloads): https://msdn.microsoft.com/en-us/library/bb524831.aspx
-
-2. Run the script from a cmd prompt:
-    ```
-    @"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/jonescompneurolab/hnn/master/installer/windows/hnn.ps1'))"
-    ```
-    OR from a powershell prompt:
-    ```
-    Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/jonescompneurolab/hnn/master/installer/windows/hnn.ps1'))
-    ```
-    OR from a local copy:
-    ```
-    powershell.exe -ExecutionPolicy Bypass -File .\hnn\installer\windows\hnn.ps1
-    ```
-   * There will be a permission prompt to install Microsoft MPI and a couple of terminal windows will
-open up. There will be a prompt for pressing ENTER after nrnmech.dll has been built
-   * If an existing Python 3.X installation isn't found, expect that installation will pause for ~5min while installing Miniconda
-
-3. After the script has completed, instructions will be displayed for using the environment either with virtualenv or Miniconda. Open up a new cmd.exe window (not PowerShell) for the environment variables to get set in the session.
-4. Run:
-    ```
-    activate hnn
-    cd hnn
-    python hnn.py hnn.cfg
-    ```
-5. That will launch the HNN GUI. You should now be able to run the tutorials at https://hnn.brown.edu/index.php/tutorials/
-
+For other HNN software issues, please visit the [HNN bullentin board](https://www.neuron.yale.edu/phpBB/viewforum.php?f=46)

--- a/installer/windows/native_install.md
+++ b/installer/windows/native_install.md
@@ -1,0 +1,49 @@
+# HNN native install (Windows)
+
+This method will run HNN without using virtualization, meaning the GUI may feel more responsive and simulations may run slightly faster. However, the procedure is a set of steps that the user must follow, and there is a possibility that differences in the base environment may require additional troubleshooting. Thus, it is best suited for advanced users. For the recommended Docker-based installation please see the instructions below.
+  - Alternative: [Docker install instructions](README.md)
+
+A [PowerShell install script](hnn.ps1) will manage downloading all prerequisites except Microsoft MPI which requires a web browser to download. If the script finds msmpisetup.exe in the Downloads folder, it will take care of installing it.
+
+## Requirements
+ - A 64-bit OS
+ - Windows 7 or later. Windows Vista is not supported for lack of multiprocessing support.
+ - PowerShell version 1.0 or later. If PowerShell is not installed, please follow the link below for downloading and running the PowerShell installer:
+ https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell
+
+## Prerequisite: Microsoft MPI
+
+1. Download Microsoft MPI (msmpisetup.exe) from the link below and save it to the user's Downloads  folder (C:\Users\\[MY_USERNAME]\Downloads): https://msdn.microsoft.com/en-us/library/bb524831.aspx
+
+## Run install script
+
+1. Run the script from a cmd prompt:
+    ```
+    @"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/jonescompneurolab/hnn/master/installer/windows/hnn.ps1'))"
+    ```
+    OR from a powershell prompt:
+    ```
+    Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/jonescompneurolab/hnn/master/installer/windows/hnn.ps1'))
+    ```
+    OR from a local copy:
+    ```
+    powershell.exe -ExecutionPolicy Bypass -File .\hnn\installer\windows\hnn.ps1
+    ```
+   * There will be a permission prompt to install Microsoft MPI and a couple of terminal windows will
+open up. There will be a prompt for pressing ENTER after nrnmech.dll has been built
+   * If an existing Python 3.X installation isn't found, expect that installation will pause for ~5min while installing Miniconda
+
+2. After the script has completed, instructions will be displayed for using the environment either with virtualenv or Miniconda. Open up a new cmd.exe window (not PowerShell) for the environment variables to get set in the session.
+3. Run:
+    ```
+    activate hnn
+    cd hnn
+    python hnn.py hnn.cfg
+    ```
+4. That will launch the HNN GUI. You should now be able to run the tutorials at https://hnn.brown.edu/index.php/tutorials/
+
+# Troubleshooting
+
+If you run into other issues with the installation, please [open an issue on our GitHub](https://github.com/jonescompneurolab/hnn/issues). Our team monitors these issues and will investigate possible fixes.
+
+For other HNN software issues, please visit the [HNN bullentin board](https://www.neuron.yale.edu/phpBB/viewforum.php?f=46)


### PR DESCRIPTION
In order to make it more apparent that the docker-based installation is
the recommended method, separate the native install instructions into a
separate file that a user would have to intentionally chose (marked for
advanced users).

Include instructions on creating a Docker Hub account in Mac and
Windows guides.

Also separate troubleshooting page for Mac into its own file.