### PR TITLE
Update docker container to try all known DISPLAY's

### DIFF
--- a/installer/docker/Dockerfile
+++ b/installer/docker/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get update && \
                        bison flex automake libtool libxext-dev libncurses-dev \
                        python3-dev xfonts-100dpi cython libopenmpi-dev python3-scipy \
                        python3-pyqt4.qtopengl libxaw7 libxmu6 libxpm4 \
-                       git vim iputils-ping net-tools iproute2 nano sudo && \
+                       git vim iputils-ping net-tools iproute2 nano sudo \
+                       telnet && \
     apt-get remove -y python3-matplotlib
 
 # use pip for matplotlib to get latest version (2.x) since apt-get was using older

--- a/installer/docker/start_hnn.sh
+++ b/installer/docker/start_hnn.sh
@@ -9,7 +9,32 @@ else
 fi
 
 cd /home/hnn_user/hnn_repo
-python3 hnn.py hnn.cfg
+
+done=
+XHOST=${DISPLAY%:0}
+# try some common hosts
+for XHOST in $XHOST 192.168.99.1 192.168.65.2 ""; do
+  for PORT in 0 1 2 3 4; do
+    export DISPLAY=$XHOST:$PORT
+    echo "Trying to start HNN with DISPLAY=$DISPLAY"
+    python3 hnn.py hnn.cfg
+    if [[ "$?" -ne "0" ]]; then
+      echo "HNN failed to start GUI using DISPLAY=$DISPLAY"
+    else
+      done=1
+      break
+    fi
+  done
+  if [[ "$done" -eq "1" ]]; then
+    break
+  fi
+done
+
+if [[ "$done" -eq "1" ]]; then
+  echo "HNN GUI stopped by user. Restart container to open again"
+else
+  echo "Failed to start HNN on any X port at host"
+fi
 
 # fallback to sleep infinity so that container won't stop if hnn is closed
 sleep infinity


### PR DESCRIPTION
This was causing some users trouble when XQuartz would unexpectedly use
a different display port. Just try them all because it is pretty fast,
but give users meaningful messages in the debug output.