### PR TITLE
Optimize bin width of input time histograms for each type of input.

### DIFF
--- a/simdat.py
+++ b/simdat.py
@@ -290,19 +290,19 @@ class SIMCanvas (FigureCanvas):
         print(len(dinput['dist']),len(dinput['prox']),len(dinput['evdist']),len(dinput['evprox']),len(dinput['pois']))
 
       if hasPois: # any Poisson inputs?
-        hist['feed_pois'] = extinputs.plot_hist(self.axpois,'pois',ddat['dpl'][:,0],None,xl,color='k',hty='step',lw=self.gui.linewidth+1)
+        hist['feed_pois'] = extinputs.plot_hist(self.axpois,'pois',ddat['dpl'][:,0],'auto',xl,color='k',hty='step',lw=self.gui.linewidth+1)
 
       if len(dinput['dist']) > 0 and dinty['OngoingDist']: # dinty condition ensures synaptic weight > 0
-        hist['feed_dist'] = extinputs.plot_hist(self.axdist,'dist',ddat['dpl'][:,0],None,xl,color='g',lw=self.gui.linewidth+1)
+        hist['feed_dist'] = extinputs.plot_hist(self.axdist,'dist',ddat['dpl'][:,0],'auto',xl,color='g',lw=self.gui.linewidth+1)
 
       if len(dinput['prox']) > 0 and dinty['OngoingProx']: # dinty condition ensures synaptic weight > 0
-        hist['feed_prox'] = extinputs.plot_hist(self.axprox,'prox',ddat['dpl'][:,0],None,xl,color='r',lw=self.gui.linewidth+1)
+        hist['feed_prox'] = extinputs.plot_hist(self.axprox,'prox',ddat['dpl'][:,0],'auto',xl,color='r',lw=self.gui.linewidth+1)
 
       if len(dinput['evdist']) > 0 and dinty['EvokedDist']: # dinty condition ensures synaptic weight > 0
-        hist['feed_evdist'] = extinputs.plot_hist(self.axdist,'evdist',ddat['dpl'][:,0],None,xl,color='g',hty='step',lw=self.gui.linewidth+1)
+        hist['feed_evdist'] = extinputs.plot_hist(self.axdist,'evdist',ddat['dpl'][:,0],'auto',xl,color='g',hty='step',lw=self.gui.linewidth+1)
 
       if len(dinput['evprox']) > 0 and dinty['EvokedProx']: # dinty condition ensures synaptic weight > 0
-        hist['feed_evprox'] = extinputs.plot_hist(self.axprox,'evprox',ddat['dpl'][:,0],None,xl,color='r',hty='step',lw=self.gui.linewidth+1)
+        hist['feed_evprox'] = extinputs.plot_hist(self.axprox,'evprox',ddat['dpl'][:,0],'auto',xl,color='r',hty='step',lw=self.gui.linewidth+1)
     elif plot_distribs:
       if len(dinput['evprox']) > 0 and dinty['EvokedProx']: # dinty condition ensures synaptic weight > 0
         prox_tot = np.zeros(len(dinput['evprox'][0][0]))

--- a/simdat.py
+++ b/simdat.py
@@ -242,9 +242,6 @@ class SIMCanvas (FigureCanvas):
         dinty = dict of input types used, determines how many/which axes created/displayed
     """
 
-    # set number of bins (150 bins per 1000ms)
-    bins = ceil(150. * (xl[1] - xl[0]) / 1000.) # bins needs to be an int
-    if debug: print('bins:',bins)
     extinputs = None
     plot_distribs = False
 
@@ -293,19 +290,19 @@ class SIMCanvas (FigureCanvas):
         print(len(dinput['dist']),len(dinput['prox']),len(dinput['evdist']),len(dinput['evprox']),len(dinput['pois']))
 
       if hasPois: # any Poisson inputs?
-        hist['feed_pois'] = extinputs.plot_hist(self.axpois,'pois',ddat['dpl'][:,0],bins,xl,color='k',hty='step',lw=self.gui.linewidth+1)
+        hist['feed_pois'] = extinputs.plot_hist(self.axpois,'pois',ddat['dpl'][:,0],None,xl,color='k',hty='step',lw=self.gui.linewidth+1)
 
       if len(dinput['dist']) > 0 and dinty['OngoingDist']: # dinty condition ensures synaptic weight > 0
-        hist['feed_dist'] = extinputs.plot_hist(self.axdist,'dist',ddat['dpl'][:,0],bins,xl,color='g',lw=self.gui.linewidth+1)
+        hist['feed_dist'] = extinputs.plot_hist(self.axdist,'dist',ddat['dpl'][:,0],None,xl,color='g',lw=self.gui.linewidth+1)
 
       if len(dinput['prox']) > 0 and dinty['OngoingProx']: # dinty condition ensures synaptic weight > 0
-        hist['feed_prox'] = extinputs.plot_hist(self.axprox,'prox',ddat['dpl'][:,0],bins,xl,color='r',lw=self.gui.linewidth+1)
+        hist['feed_prox'] = extinputs.plot_hist(self.axprox,'prox',ddat['dpl'][:,0],None,xl,color='r',lw=self.gui.linewidth+1)
 
       if len(dinput['evdist']) > 0 and dinty['EvokedDist']: # dinty condition ensures synaptic weight > 0
-        hist['feed_evdist'] = extinputs.plot_hist(self.axdist,'evdist',ddat['dpl'][:,0],bins,xl,color='g',hty='step',lw=self.gui.linewidth+1)
+        hist['feed_evdist'] = extinputs.plot_hist(self.axdist,'evdist',ddat['dpl'][:,0],None,xl,color='g',hty='step',lw=self.gui.linewidth+1)
 
       if len(dinput['evprox']) > 0 and dinty['EvokedProx']: # dinty condition ensures synaptic weight > 0
-        hist['feed_evprox'] = extinputs.plot_hist(self.axprox,'evprox',ddat['dpl'][:,0],bins,xl,color='r',hty='step',lw=self.gui.linewidth+1)
+        hist['feed_evprox'] = extinputs.plot_hist(self.axprox,'evprox',ddat['dpl'][:,0],None,xl,color='r',hty='step',lw=self.gui.linewidth+1)
     elif plot_distribs:
       if len(dinput['evprox']) > 0 and dinty['EvokedProx']: # dinty condition ensures synaptic weight > 0
         prox_tot = np.zeros(len(dinput['evprox'][0][0]))

--- a/spikefn.py
+++ b/spikefn.py
@@ -217,8 +217,8 @@ class ExtInputs (Spikes):
     self.inputs['t'] = t
 
   # extinput is either 'dist' or 'prox'
-  def plot_hist (self, ax, extinput, tvec, bins=None, xlim=None, color='green', hty='bar',lw=4):
-    if bins is None:
+  def plot_hist (self, ax, extinput, tvec, bins='auto', xlim=None, color='green', hty='bar',lw=4):
+    if bins is 'auto':
         bins = hist_bin_opt(self.inputs[extinput], 1)
     if not xlim:
       xlim = (0., p_dict['tstop'])

--- a/spikefn.py
+++ b/spikefn.py
@@ -166,7 +166,7 @@ class ExtInputs (Spikes):
     if len(self.inputs['evdist']) > 0:
       if self.evdist_gid_range[0] <= gid <= self.evdist_gid_range[1]:
         return True
-    return False    
+    return False
 
   # check if gid is associated with a proximal input
   def is_prox_gid (self, gid):
@@ -180,7 +180,7 @@ class ExtInputs (Spikes):
     if gid == self.gid_dist: return True
     if len(self.inputs['evdist']) > 0:
       return self.evdist_gid_range[0] <= gid <= self.evdist_gid_range[1]
-    return False    
+    return False
 
   # check if gid is associated with a Poisson input
   def is_pois_gid (self, gid):
@@ -202,7 +202,7 @@ class ExtInputs (Spikes):
   def add_delay_times (self):
     # if prox delay to both layers is the same, add it to the prox input times
     if self.p_dict['input_prox_A_delay_L2'] == self.p_dict['input_prox_A_delay_L5']:
-      self.inputs['prox'] += self.p_dict['input_prox_A_delay_L2']          
+      self.inputs['prox'] += self.p_dict['input_prox_A_delay_L2']
     # if dist delay to both layers is the same, add it to the dist input times
     if self.p_dict['input_dist_A_delay_L2'] == self.p_dict['input_dist_A_delay_L5']:
       self.inputs['dist'] += self.p_dict['input_dist_A_delay_L2']
@@ -217,7 +217,9 @@ class ExtInputs (Spikes):
     self.inputs['t'] = t
 
   # extinput is either 'dist' or 'prox'
-  def plot_hist (self, ax, extinput, tvec, bins=150, xlim=None, color='green', hty='bar',lw=4):
+  def plot_hist (self, ax, extinput, tvec, bins=None, xlim=None, color='green', hty='bar',lw=4):
+    if bins is None:
+        bins = hist_bin_opt(self.inputs[extinput], 1)
     if not xlim:
       xlim = (0., p_dict['tstop'])
     if len(self.inputs[extinput]):
@@ -445,7 +447,7 @@ def pinput_hist(a0, a1, s_list0, s_list1, n_bins, xlim):
 def pinput_hist_onesided(a0, s_list, n_bins):
   hists = {
     'prox': a0.hist(s_list, n_bins, color='k', label='Proximal input', alpha=0.75),
-  }  
+  }
   return hists
 
 if __name__ == '__main__':


### PR DESCRIPTION
By default, the 'bins' parameter is now optimized within spikefn.py (hopefully without breaking any other calls to the spikefn.plot_hist() function).

Here are some samples of the new histogram output:

![Screen Shot 2019-08-20 at 4 15 20 PM](https://user-images.githubusercontent.com/20212206/63381933-af345100-c367-11e9-91e5-f2dfd86984cf.png)

![Screen Shot 2019-08-20 at 4 15 32 PM](https://user-images.githubusercontent.com/20212206/63381950-b4919b80-c367-11e9-9048-79ebd21a0486.png)
