### PR TITLE
Update docker build to create hnn_out as user

### DIFF
--- a/installer/centos/README.md
+++ b/installer/centos/README.md
@@ -6,9 +6,9 @@ This guide describes installing HNN on CentOS using Docker. This method will aut
 
 ## Verify that your OS supports Docker CE
 
-    - CentOS 7 and later versions are supported
-    - See [OS requirements](https://docs.docker.com/install/linux/docker-ce/centos/#os-requirements)
-    - It may be possible to install older versions of docker meant for earlier CentOS versions. We recommend following the currently supported procedure from Docker, but you may find a version of Docker in the [EPEL repositories](https://fedoraproject.org/wiki/EPEL) for CentOS 6, which would would work for your OS.
+- CentOS 7 and later versions are supported
+- See [OS requirements](https://docs.docker.com/install/linux/docker-ce/centos/#os-requirements)
+- It may be possible to install older versions of docker meant for earlier CentOS versions. We recommend following the currently supported procedure from Docker, but you may find a version of Docker in the [EPEL repositories](https://fedoraproject.org/wiki/EPEL) for CentOS 6, which would would work for your OS.
 
 ## Prerequisite: install Docker
 
@@ -24,6 +24,8 @@ This guide describes installing HNN on CentOS using Docker. This method will aut
     sudo yum install -y docker-ce docker-ce-cli containerd.io
     # start docker
     sudo systemctl start docker
+    # automatically start docker on boot
+    sudo systemctl enable docker
     # verify that docker runs
     sudo docker run hello-world
     ```
@@ -68,8 +70,7 @@ Open a bash terminal and run these commands (from [Docker Compose installation](
 4. Start the Docker container. Note: the jonescompneurolab/hnn Docker image will be downloaded from Docker Hub (about 2 GB). The docker-compose command can be used to manage Docker containers described in the specification file docker-compose.yml.
 
     ```bash
-    $ docker-compose run hnn
-    Creating network "docker_default" with the default driver
+    $ docker-compose up
     Pulling hnn (jonescompneurolab/hnn:)...
     latest: Pulling from jonescompneurolab/hnn
     34dce65423d3: Pull complete
@@ -77,50 +78,42 @@ Open a bash terminal and run these commands (from [Docker Compose installation](
     2a0eada9611d: Pull complete
     d6830a7cd972: Pull complete
     ddf2bf28e180: Pull complete
-    1b92ede96ea9: Pull complete
-    d40cff005cd9: Pull complete
-    8c2b6fabd4cd: Pull complete
-    739b6844c557: Pull complete
-    93e57038c24c: Pull complete
-    8a0c9da0fc98: Pull complete
-    87b245fb518f: Pull complete
-    Digest: sha256:c561d0880aa8c69995dfc84e2c456b7dea688f829bfbadedfed94425c1f2044c
-    Status: Downloaded newer image for jonescompneurolab/hnn:latest
+    3cc50322f9e6: Pull complete
+    413f53de8db6: Pull complete
+    17dc3d1b2db0: Pull complete
+    630b5e60ea64: Pull complete
+    78e9a198ddb9: Pull complete
+    45d8623e986c: Pull complete
+    e32873c7bf4d: Pull complete
+    Creating hnn_container ... done
+    Attaching to hnn_container
     ```
 
 5. The HNN GUI should show up. Make sure that you can run simulations by clicking the 'Run Simulation' button. This will run a simulation with the default configuration. After it completes, graphs should be displayed in the main window.
-6. You can now proceed to running the tutorials at https://hnn.brown.edu/index.php/tutorials/ . Some things to note:
+6. You can now proceed to running the tutorials at [https://hnn.brown.edu/index.php/tutorials/](https://hnn.brown.edu/index.php/tutorials/) . Some things to note:
    - A directory called "hnn_out" exists both inside the container (at /home/hnn_user/hnn_out) and outside (in the directory set by step 2) that can be used to share files between the container and your host OS.
    - The HNN repository with sample data and parameter files exists at /home/hnn_user/hnn_source_code.
    - If you run into problems starting the Docker container or the GUI is not displaying, please see the [Docker troubleshooting section](../docker/README.md#Troubleshooting)
 
 ## Updgrading to a new version of HNN
 
-1. Verify Docker is still running. To confirm that Docker is running properly, typing `docker info` should return a bunch of output, but no errors.
+Whenever the `docker-compose up` command is run, docker will check for a new version of the hnn container image and download it if necessary. You can perform the download step explicitly as well:
 
-    ```bash
-    $ docker info
-    ```
-
-2. Open a terminal window
-
-    ```bash
-    $ cd hnn/installer/docker
-    $ docker-compose up --no-start
-    Recreating docker_hnn_1 ... done
-    $ docker-compose run hnn
-    ```
+```bash
+$ cd hnn/installer/docker
+$ docker-compose up --no-start
+```
 
 ## Editing files within HNN container
 
-You may want run commands or edit files within the container. To access a command shell in the container, start the container using `docker-compose run hnn` in one terminal window and open another terminal to use [`docker exec`](https://docs.docker.com/engine/reference/commandline/exec/) as shown below:
+You may want run commands or edit files within the container. To access a command shell in the container, start the container using `docker-compose up -d` to start hnn in the background and use [`docker exec`](https://docs.docker.com/engine/reference/commandline/exec/) as shown below:
 
-    ```bash
-    $ docker exec -ti docker_hnn_1 bash
-    hnn_user@054ba0c64625:/home/hnn_user$
-    ```
+```bash
+$ docker exec -ti hnn_container bash
+hnn_user@hnn-container:/home/hnn_user/hnn_source_code$
+```
 
-    If you'd like to be able to copy files from the host OS without using the shared directory, you do so directly with [`docker cp`](https://docs.docker.com/engine/reference/commandline/cp/).
+If you'd like to be able to copy files from the host OS without using the shared directory, you do so directly with [`docker cp`](https://docs.docker.com/engine/reference/commandline/cp/).
 
 ## Uninstalling HNN
 

--- a/installer/docker/Dockerfile
+++ b/installer/docker/Dockerfile
@@ -66,6 +66,8 @@ COPY start_hnn.sh /home/hnn_user/
 RUN sudo chown hnn_user:hnn_group /home/hnn_user/start_hnn.sh && \
     sudo chmod +x /home/hnn_user/start_hnn.sh
 
+RUN mkdir /home/hnn_user/hnn_out
+
 ARG CACHEBUST=1
 
 RUN cd /home/hnn_user && \

--- a/installer/docker/docker-compose.yml
+++ b/installer/docker/docker-compose.yml
@@ -3,6 +3,8 @@ services:
 
   hnn:
     image: jonescompneurolab/hnn
+    container_name: hnn_container
+    hostname: hnn-container
     environment:
       XAUTHORITY: "/.Xauthority"
       DISPLAY: ":0"

--- a/installer/docker/start_hnn.sh
+++ b/installer/docker/start_hnn.sh
@@ -25,7 +25,7 @@ export PATH=$PATH:/home/hnn_user/nrn/build/$CPU/bin
 
 # get rid of warning about XDG_RUNTIME_DIR
 export XDG_RUNTIME_DIR=/tmp/runtime-hnn_user
-mkdir /tmp/runtime-hnn_user
+mkdir /tmp/runtime-hnn_user &> /dev/null
 chmod 700 /tmp/runtime-hnn_user
 
 # try once with current DISPLAY

--- a/installer/mac/docker-compose.yml
+++ b/installer/mac/docker-compose.yml
@@ -3,6 +3,8 @@ services:
 
   hnn:
     image: jonescompneurolab/hnn
+    container_name: hnn_container
+    hostname: hnn-container
     environment:
       XAUTHORITY: "/.Xauthority"
       DISPLAY: "host.docker.internal:0"

--- a/installer/mac/docker-desktop.md
+++ b/installer/mac/docker-desktop.md
@@ -57,56 +57,49 @@
 3. Start the Docker container. Note: the jonescompneurolab/hnn Docker image will be downloaded from Docker Hub (about 2 GB). The `docker-compose` command can be used to manage Docker containers described in the specification file docker-compose.yml.
 
     ```bash
-    $ docker-compose run hnn
+    $ docker-compose up
     Pulling hnn (jonescompneurolab/hnn:)...
     latest: Pulling from jonescompneurolab/hnn
-    34dce65423d3: Already exists
-    796769e96d24: Already exists
-    2a0eada9611d: Already exists
-    d6830a7cd972: Already exists
-    ddf2bf28e180: Already exists
-    77bf1279b29f: Pull complete
-    6c8ddf82616f: Pull complete
-    a991616934ba: Pull complete
-    2cece6240c19: Pull complete
-    df826e7d26b9: Pull complete
-    824d51cbc89d: Pull complete
-    0d16f27c744b: Pull complete
-    Digest: sha256:0c27e2027828d2510a8867773562bbc966c509f45c9921cc2d1973c575d327b3
-    Status: Downloaded newer image for jonescompneurolab/hnn:latest
+    34dce65423d3: Pull complete
+    796769e96d24: Pull complete
+    2a0eada9611d: Pull complete
+    d6830a7cd972: Pull complete
+    ddf2bf28e180: Pull complete
+    3cc50322f9e6: Pull complete
+    413f53de8db6: Pull complete
+    17dc3d1b2db0: Pull complete
+    630b5e60ea64: Pull complete
+    78e9a198ddb9: Pull complete
+    45d8623e986c: Pull complete
+    e32873c7bf4d: Pull complete
+    Creating hnn_container ... done
+    Attaching to hnn_container
     ```
 
 4. The HNN GUI should show up. Make sure that you can run simulations by clicking the 'Run Simulation' button. This will run a simulation with the default configuration. After it completes, graphs should be displayed in the main window.
     * If starting the GUI doesn't work, the first thing to check is XQuartz settings (see screnshot above). Then restart XQuartz and try starting the HNN container again.
-5. You can now proceed to running the tutorials at https://hnn.brown.edu/index.php/tutorials/ . Some things to note:
+5. You can now proceed to running the tutorials at [https://hnn.brown.edu/index.php/tutorials/](https://hnn.brown.edu/index.php/tutorials/) . Some things to note:
    * A directory called "hnn_out" exists both inside the container (at /home/hnn_user/hnn_out) and outside (in the directory set by step 2) that can be used to share files between the container and your host OS.
    * The HNN repository with sample data and parameter files exists at /home/hnn_user/hnn_source_code.
    * If you run into problems starting the Docker container or the GUI is not displaying, please see the [Docker troubleshooting section](../docker/README.md#Troubleshooting)
 
 ## Updgrading to a new version of HNN
 
-1. Verify that XQuartz and Docker are running. XQuartz will not start automatically after a reboot by default. To confirm that Docker is running properly, typing `docker info` should return a bunch of output, but no errors.
+Whenever the `docker-compose up` command is run, docker will check for a new version of the hnn container image and download it if necessary. You can perform the download step explicitly as well:
 
-    ```bash
-    $ docker info
-    ```
-
-2. Open a terminal window
-
-    ```bash
-    $ cd hnn/installer/mac
-    $ docker-compose up --no-start
-    Recreating mac_hnn_1 ... done
-    $ docker-compose run hnn
-    ```
+```bash
+$ cd hnn/installer/mac
+$ docker-compose up --no-start
+Recreating hnn_container ... done
+```
 
 ## Editing files within HNN container
 
-You may want run commands or edit files within the container. To access a command shell in the container, start the container using `docker-compose run hnn` in one terminal window and open another terminal to use [`docker exec`](https://docs.docker.com/engine/reference/commandline/exec/) as shown below:
+You may want run commands or edit files within the container. To access a command shell in the container, start the container using `docker-compose up -d` to start hnn in the background and use [`docker exec`](https://docs.docker.com/engine/reference/commandline/exec/) as shown below:
 
 ```bash
-$ docker exec -ti mac_hnn_1 bash
-hnn_user@054ba0c64625:/home/hnn_user$
+$ docker exec -ti hnn_container bash
+hnn_user@hnn-container:/home/hnn_user/hnn_source_code$
 ```
 
 If you'd like to be able to copy files from the host OS without using the shared directory, you do so directly with [`docker cp`](https://docs.docker.com/engine/reference/commandline/cp/).
@@ -116,7 +109,7 @@ If you'd like to be able to copy files from the host OS without using the shared
 If you want to remove the container and 1.5 GB HNN image, run the following commands from a terminal window. You can then remove Docker Desktop by removing it from your Applications folder.
 
 ```bash
-$ docker rm -f mac_hnn_1
+$ docker rm -f hnn_container
 $ docker rmi jonescompneurolab/hnn
 ```
 

--- a/installer/mac/docker-toolbox.md
+++ b/installer/mac/docker-toolbox.md
@@ -57,7 +57,7 @@
 3. Start the Docker container. Note: the jonescompneurolab/hnn Docker image will be downloaded from Docker Hub (about 2 GB). The `docker-compose` command can be used to manage Docker containers described in the specification file docker-compose.yml.
 
     ```bash
-    $ docker-compose run -e "DISPLAY=192.168.99.1:0" hnn
+    $ docker-compose run -e "DISPLAY=192.168.99.1:0" --name hnn_container hnn
     Pulling hnn (jonescompneurolab/hnn:)...
     latest: Pulling from jonescompneurolab/hnn
     34dce65423d3: Already exists
@@ -78,7 +78,7 @@
 
 4. The HNN GUI should show up. Make sure that you can run simulations by clicking the 'Run Simulation' button. This will run a simulation with the default configuration. After it completes, graphs should be displayed in the main window.
     * If starting the GUI doesn't work the first time, the first thing to check is XQuartz settings (see screnshot above). Then restart XQuartz and try starting the HNN container again.
-5. You can now proceed to running the tutorials at https://hnn.brown.edu/index.php/tutorials/ . Some things to note:
+5. You can now proceed to running the tutorials at https://hnn.brown.edu/index.php/tutorials/](https://hnn.brown.edu/index.php/tutorials/) . Some things to note:
    * A directory called "hnn_out" exists both inside the container (at /home/hnn_user/hnn_out) and outside (in the directory set by step 2) that can be used to share files between the container and your host OS.
    * The HNN repository with sample data and parameter files exists at /home/hnn_user/hnn_source_code.
    * If you run into problems starting the Docker container or the GUI is not displaying, please see the [Docker troubleshooting section](../docker/README.md#Troubleshooting)
@@ -99,8 +99,7 @@ The Docker Toolbox VM will remain running the background using some resources. I
     ```bash
     $ cd hnn/installer/mac
     $ docker-compose up --no-start
-    Recreating mac_hnn_1 ... done
-    $ docker-compose run -e "DISPLAY=192.168.99.1:0" hnn
+    Recreating hnn_container ... done
     ```
 
 ## Editing files within HNN container
@@ -108,8 +107,8 @@ The Docker Toolbox VM will remain running the background using some resources. I
 You may want run commands or edit files within the container. To access a command shell in the container, start the container using `docker-compose run hnn` in one terminal window and open another terminal to use [`docker exec`](https://docs.docker.com/engine/reference/commandline/exec/) as shown below:
 
 ```bash
-$ docker exec -ti mac_hnn_1 bash
-hnn_user@054ba0c64625:/home/hnn_user$
+$ docker exec -ti hnn_container bash
+hnn_user@hnn-container:/home/hnn_user/hnn_source_code$
 ```
 
 If you'd like to be able to copy files from the host OS without using the shared directory, you do so directly with [`docker cp`](https://docs.docker.com/engine/reference/commandline/cp/).
@@ -119,7 +118,7 @@ If you'd like to be able to copy files from the host OS without using the shared
 If you want to remove the container and 1.5 GB HNN image, run the following commands from a terminal window. You can then remove Docker Desktop by removing it from your Applications folder.
 
 ```bash
-$ docker rm -f mac_hnn_1
+$ docker rm -f hnn_container
 $ docker rmi jonescompneurolab/hnn
 ```
 

--- a/installer/ubuntu/README.md
+++ b/installer/ubuntu/README.md
@@ -70,8 +70,7 @@ Open a bash terminal and run these commands (from [Docker Compose installation](
 4. Start the Docker container. Note: the jonescompneurolab/hnn Docker image will be downloaded from Docker Hub (about 2 GB). The docker-compose command can be used to manage Docker containers described in the specification file docker-compose.yml.
 
     ```bash
-    $ docker-compose run hnn
-    Creating network "docker_default" with the default driver
+    $ docker-compose up
     Pulling hnn (jonescompneurolab/hnn:)...
     latest: Pulling from jonescompneurolab/hnn
     34dce65423d3: Pull complete
@@ -79,57 +78,49 @@ Open a bash terminal and run these commands (from [Docker Compose installation](
     2a0eada9611d: Pull complete
     d6830a7cd972: Pull complete
     ddf2bf28e180: Pull complete
-    1b92ede96ea9: Pull complete
-    d40cff005cd9: Pull complete
-    8c2b6fabd4cd: Pull complete
-    739b6844c557: Pull complete
-    93e57038c24c: Pull complete
-    8a0c9da0fc98: Pull complete
-    87b245fb518f: Pull complete
-    Digest: sha256:c561d0880aa8c69995dfc84e2c456b7dea688f829bfbadedfed94425c1f2044c
-    Status: Downloaded newer image for jonescompneurolab/hnn:latest
+    3cc50322f9e6: Pull complete
+    413f53de8db6: Pull complete
+    17dc3d1b2db0: Pull complete
+    630b5e60ea64: Pull complete
+    78e9a198ddb9: Pull complete
+    45d8623e986c: Pull complete
+    e32873c7bf4d: Pull complete
+    Creating hnn_container ... done
+    Attaching to hnn_container
     ```
 
 5. The HNN GUI should show up. Make sure that you can run simulations by clicking the 'Run Simulation' button. This will run a simulation with the default configuration. After it completes, graphs should be displayed in the main window.
-6. You can now proceed to running the tutorials at https://hnn.brown.edu/index.php/tutorials/ . Some things to note:
+6. You can now proceed to running the tutorials at [https://hnn.brown.edu/index.php/tutorials/](https://hnn.brown.edu/index.php/tutorials/) . Some things to note:
    - A directory called "hnn_out" exists both inside the container (at /home/hnn_user/hnn_out) and outside (in the directory set by step 2) that can be used to share files between the container and your host OS.
    - The HNN repository with sample data and parameter files exists at /home/hnn_user/hnn_source_code.
    - If you run into problems starting the Docker container or the GUI is not displaying, please see the [Docker troubleshooting section](../docker/README.md#Troubleshooting)
 
 ## Updgrading to a new version of HNN
 
-1. Verify Docker is still running. To confirm that Docker is running properly, typing `docker info` should return a bunch of output, but no errors.
+Whenever the `docker-compose up` command is run, docker will check for a new version of the hnn container image and download it if necessary. You can perform the download step explicitly as well:
 
-    ```bash
-    $ docker info
-    ```
-
-2. Open a terminal window
-
-    ```bash
-    $ cd hnn/installer/docker
-    $ docker-compose up --no-start
-    Recreating docker_hnn_1 ... done
-    $ docker-compose run hnn
-    ```
+```bash
+$ cd hnn/installer/docker
+$ docker-compose up --no-start
+```
 
 ## Editing files within HNN container
 
-You may want run commands or edit files within the container. To access a command shell in the container, start the container using `docker-compose run hnn` in one terminal window and open another terminal to use [`docker exec`](https://docs.docker.com/engine/reference/commandline/exec/) as shown below:
+You may want run commands or edit files within the container. To access a command shell in the container, start the container using `docker-compose up -d` to start hnn in the background and use [`docker exec`](https://docs.docker.com/engine/reference/commandline/exec/) as shown below:
 
-    ```bash
-    $ docker exec -ti docker_hnn_1 bash
-    hnn_user@054ba0c64625:/home/hnn_user$
-    ```
+```bash
+$ docker exec -ti hnn_container bash
+hnn_user@hnn-container:/home/hnn_user/hnn_source_code$
+```
 
-    If you'd like to be able to copy files from the host OS without using the shared directory, you do so directly with [`docker cp`](https://docs.docker.com/engine/reference/commandline/cp/).
+If you'd like to be able to copy files from the host OS without using the shared directory, you do so directly with [`docker cp`](https://docs.docker.com/engine/reference/commandline/cp/).
 
 ## Uninstalling HNN
 
 1. If you want to just remove the container and 2 GB HNN image, run these commands from a terminal window:
 
     ```bash
-    $ docker rm -f docker_hnn_1
+    $ docker rm -f hnn_container
     $ docker rmi jonescompneurolab/hnn
     ```
 

--- a/installer/windows/docker-compose.yml
+++ b/installer/windows/docker-compose.yml
@@ -3,6 +3,8 @@ services:
 
   hnn:
     image: jonescompneurolab/hnn
+    container_name: hnn_container
+    hostname: hnn-container
     environment:
       XAUTHORITY: "/.Xauthority"
       DISPLAY: "host.docker.internal:0"

--- a/installer/windows/docker-desktop.md
+++ b/installer/windows/docker-desktop.md
@@ -92,23 +92,23 @@ There are two related requirements needed for Docker to be able to run HNN in a 
 3. Start the Docker container. Note: the jonescompneurolab/hnn Docker image will be downloaded from Docker Hub (about 2 GB). The docker-compose command can be used to manage Docker containers described in the specification file docker-compose.yml.
 
     ```powershell
-    C:\Users\myuser\hnn\installer\windows> docker-compose run hnn
+    C:\Users\myuser\hnn\installer\windows> docker-compose up
     Pulling hnn (jonescompneurolab/hnn:)...
     latest: Pulling from jonescompneurolab/hnn
-    34dce65423d3: Already exists
-    796769e96d24: Already exists
-    2a0eada9611d: Already exists
-    d6830a7cd972: Already exists
-    ddf2bf28e180: Already exists
-    77bf1279b29f: Pull complete
-    6c8ddf82616f: Pull complete
-    a991616934ba: Pull complete
-    2cece6240c19: Pull complete
-    df826e7d26b9: Pull complete
-    824d51cbc89d: Pull complete
-    0d16f27c744b: Pull complete
-    Digest: sha256:0c27e2027828d2510a8867773562bbc966c509f45c9921cc2d1973c575d327b3
-    Status: Downloaded newer image for jonescompneurolab/hnn:latest
+    34dce65423d3: Pull complete
+    796769e96d24: Pull complete
+    2a0eada9611d: Pull complete
+    d6830a7cd972: Pull complete
+    ddf2bf28e180: Pull complete
+    3cc50322f9e6: Pull complete
+    413f53de8db6: Pull complete
+    17dc3d1b2db0: Pull complete
+    630b5e60ea64: Pull complete
+    78e9a198ddb9: Pull complete
+    45d8623e986c: Pull complete
+    e32873c7bf4d: Pull complete
+    Creating hnn_container ... done
+    Attaching to hnn_container
     ```
 
 4. If a prompt appears from the lower-right and ask you to share the drive, click 'Share'.
@@ -118,30 +118,27 @@ There are two related requirements needed for Docker to be able to run HNN in a 
    <img src="install_pngs/access_filesystem.png" width="300" />
 
 6. The HNN GUI should show up. Make sure that you can run simulations by clicking the 'Run Simulation' button. This will run a simulation with the default configuration. After it completes, graphs should be displayed in the main window.
-7. You can now proceed to running the tutorials at https://hnn.brown.edu/index.php/tutorials/ . Some things to note:
+7. You can now proceed to running the tutorials at [https://hnn.brown.edu/index.php/tutorials/](https://hnn.brown.edu/index.php/tutorials/) . Some things to note:
    * A directory called "hnn_out" exists both inside the container (at /home/hnn_user/hnn_out) and outside (in the directory set by step 2) that can be used to share files between the container and your host OS.
    * The HNN repository with sample data and parameter files exists at /home/hnn_user/hnn_source_code
    * If you run into problems starting the Docker container or the GUI is not displaying, please see the [Docker troubleshooting section](../docker/README.md#Troubleshooting)
 
 ## Updgrading to a new version of HNN
 
-1. Verify that VcXsrv and Docker are running. VcXsrv will not start automatically after a reboot by default.
-2. Open a Command Prompt (cmd.exe)
+Whenever the `docker-compose up` command is run, docker will check for a new version of the hnn container image and download it if necessary. You can perform the download step explicitly as well from a Command Prompt (cmd.exe)
 
-    ```powershell
-    C:\Users\myuser> cd hnn\installer\windows
-    C:\Users\myuser\hnn\installer\windows> docker-compose up --no-start
-    Recreating mac_hnn_1 ... done
-    C:\Users\myuse\rhnn\installer\windows> docker-compose run hnn
-    ```
+```powershell
+C:\Users\myuser> cd hnn\installer\windows
+C:\Users\myuser\hnn\installer\windows> docker-compose up --no-start
+```
 
 ## Editing files within HNN container
 
-You may want run commands or edit files within the container. To access a command shell in the container, start the container using `docker-compose run hnn` in one Command Prompt window and open another Command Prompt window to use [`docker exec`](https://docs.docker.com/engine/reference/commandline/exec/) as shown below:
+You may want run commands or edit files within the container. To access a command shell in the container, start the container using `docker-compose up -d` to start hnn in the background and use [`docker exec`](https://docs.docker.com/engine/reference/commandline/exec/) as shown below:
 
 ```powershell
-C:\Users\myuser> docker exec -ti windows_hnn_1 bash
-hnn_user@054ba0c64625:/home/hnn_user$
+C:\Users\myuser> docker exec -ti hnn_container bash
+hnn_user@hnn-container:/home/hnn_user/hnn_source_code$
 ```
 
 If you'd like to be able to copy files from the host OS without using the shared directory, you do so directly with [`docker cp`](https://docs.docker.com/engine/reference/commandline/cp/).
@@ -151,7 +148,7 @@ If you'd like to be able to copy files from the host OS without using the shared
 If you want to remove the container and 1.5 GB HNN image, run the following commands from a cmd.exe window. You can then remove Docker Desktop using "Add/Remove Programs"
 
 ```powershell
-C:\Users\myuser> docker rm -f windows_hnn_1
+C:\Users\myuser> docker rm -f hnn_container
 C:\Users\myuser> docker rmi jonescompneurolab/hnn
 ```
 

--- a/installer/windows/docker-toolbox.md
+++ b/installer/windows/docker-toolbox.md
@@ -80,7 +80,7 @@ If you run into problems enabling hardware virtualization support, we recommend 
 3. Start the Docker container. Note: the jonescompneurolab/hnn Docker image will be downloaded from Docker Hub (about 2 GB). The docker-compose command can be used to manage Docker containers described in the specification file docker-compose.yml.
 
     ```bash
-    $ docker-compose run -e "DISPLAY=192.168.99.1:0" hnn
+    $ docker-compose run -e "DISPLAY=192.168.99.1:0" --name hnn_container hnn
     Pulling hnn (jonescompneurolab/hnn:)...
     latest: Pulling from jonescompneurolab/hnn
     34dce65423d3: Already exists
@@ -105,7 +105,7 @@ If you run into problems enabling hardware virtualization support, we recommend 
 
 5. The HNN GUI should show up. Make sure that you can run simulations by clicking the 'Run Simulation' button. This will run a simulation with the default configuration. After it completes, graphs should be displayed in the main window.
     * If starting the GUI doesn't work the first time, the first thing to check is VcXsrv settings have "Disable access control" (see above). Then restart VcXsrv and try starting the HNN container again.
-6. You can now proceed to running the tutorials at https://hnn.brown.edu/index.php/tutorials/ . Some things to note:
+6. You can now proceed to running the tutorials at [https://hnn.brown.edu/index.php/tutorials/](https://hnn.brown.edu/index.php/tutorials/) . Some things to note:
    * A directory called "hnn_out" exists both inside the container (at /home/hnn_user/hnn_out) and outside (in the directory set by step 2) that can be used to share files between the container and your host OS.
    * The HNN repository with sample data and parameter files exists at /home/hnn_user/hnn_source_code
    * If you run into problems starting the Docker container or the GUI is not displaying, please see the [Docker troubleshooting section](../docker/README.md#Troubleshooting)
@@ -126,17 +126,16 @@ The Docker Toolbox VM will remain running the background using some resources. I
     ```bash
     $ cd hnn/installer/windows
     $ docker-compose up --no-start
-    Recreating mac_hnn_1 ... done
-    $ docker-compose run hnn
+    Recreating hnn_container ... done
     ```
 
 ## Editing files within HNN container
 
-You may want run commands or edit files within the container. To access a command shell in the container, use [`docker exec`](https://docs.docker.com/engine/reference/commandline/exec/) as shown below:
+You may want run commands or edit files within the container. To access a command shell in the container, start the container using `docker-compose run hnn` in one terminal window and open another terminal to use [`docker exec`](https://docs.docker.com/engine/reference/commandline/exec/) as shown below:
 
 ```bash
-$ docker exec -ti windows_hnn_1 bash
-hnn_user@054ba0c64625:/home/hnn_user$
+$ docker exec -ti hnn_container bash
+hnn_user@hnn-container:/home/hnn_user/hnn_source_code$
 ```
 
 If you'd like to be able to copy files from the host OS without using the shared directory, you do so directly with [`docker cp`](https://docs.docker.com/engine/reference/commandline/cp/).


### PR DESCRIPTION
This ensures that the directory is created by hnn_user instead of
root. The instructions have been updated to use docker-compose up
instead of docker-compose run to ensure that the container name
remains consistent.

Fixes #82