### PR TITLE
Fix RMSE calc when exp data is shorter

### DIFF
--- a/hnn_qt5.py
+++ b/hnn_qt5.py
@@ -2523,8 +2523,9 @@ class HNNGUI (QMainWindow):
     import simdat
     self.m.clearlextdatobj()
     self.dextdata = simdat.ddat['dextdata'] = OrderedDict()
-    self.m.draw()
     self.toggleEnableOptimization(False)
+    self.m.plot()  # recreate canvas
+    self.m.draw()
 
   def setparams (self):
     # show set parameters dialog window

--- a/simdat.py
+++ b/simdat.py
@@ -126,6 +126,14 @@ def calcerr (ddat, tstop, tstart=0.0):
     exp_times = dat[:,0]
     sim_times = ddat['dpl'][:,0]
 
+    # do tstart and tstop fall within both datasets?
+    # if not, use the closest data point as the new tstop/tstart
+    for tseries in [exp_times, sim_times]:
+      if tstart <  tseries[0]:
+        tstart = tseries[0]
+      if tstop >  tseries[-1]:
+        tstop = tseries[-1]
+
     # make sure start and end times are valid for both dipoles
     exp_start_index = (np.abs(exp_times - tstart)).argmin()
     exp_end_index = (np.abs(exp_times - tstop)).argmin()
@@ -168,6 +176,14 @@ def weighted_rmse(ddat, tstop, weights, tstart=0.0):
     shp = dat.shape
     exp_times = dat[:,0]
     sim_times = ddat['dpl'][:,0]
+
+    # do tstart and tstop fall within both datasets?
+    # if not, use the closest data point as the new tstop/tstart
+    for tseries in [exp_times, sim_times]:
+      if tstart <  tseries[0]:
+        tstart = tseries[0]
+      if tstop >  tseries[-1]:
+        tstop = tseries[-1]
 
     # make sure start and end times are valid for both dipoles
     exp_start_index = (np.abs(exp_times - tstart)).argmin()

--- a/simdat.py
+++ b/simdat.py
@@ -474,11 +474,11 @@ class SIMCanvas (FigureCanvas):
 
     if self.axdipole is None:
       self.axdipole = self.figure.add_subplot(self.G[0:-1,0]) # dipole
+      xl = (0.0,1.0)
       yl = (-0.001,0.001)
     else:
+      xl = self.axdipole.get_xlim()
       yl = self.axdipole.get_ylim()
-
-    xl = (0.0,1.0)
 
     cmap=plt.get_cmap('nipy_spectral')
     csm = plt.cm.ScalarMappable(cmap=cmap);
@@ -543,27 +543,24 @@ class SIMCanvas (FigureCanvas):
 
   def clearlextdatobj (self):
     # clear list of external data objects
-    try:
-      for o in self.lextdatobj:
-        try:
-          o.set_visible(False)
-        except:
-          o[0].set_visible(False)
-      del self.lextdatobj
-      self.lextdatobj = [] # reset list of external data objects
-      self.lpatch = [] # reset legend
-      self.clridx = 5 # reset index for next color for drawing external data
+    for o in self.lextdatobj:
+      try:
+        o.set_visible(False)
+      except:
+        o[0].set_visible(False)
+    del self.lextdatobj
+    self.lextdatobj = [] # reset list of external data objects
+    self.lpatch = [] # reset legend
+    self.clridx = 5 # reset index for next color for drawing external data
 
-      if self.optMode:
-        self.lpatch.append(mpatches.Patch(color='grey', label='Optimization'))
-        self.lpatch.append(mpatches.Patch(color='black', label='Initial'))
-      elif self.hassimdata():
-        self.lpatch.append(mpatches.Patch(color='black', label='Simulation'))
-      if hasattr(self,'annot_avg'):
-        self.annot_avg.set_visible(False)
-        del self.annot_avg
-    except:
-      if debug: print('ERR: exception in clearlextdatobj')
+    if self.optMode:
+      self.lpatch.append(mpatches.Patch(color='grey', label='Optimization'))
+      self.lpatch.append(mpatches.Patch(color='black', label='Initial'))
+    elif self.hassimdata():
+      self.lpatch.append(mpatches.Patch(color='black', label='Simulation'))
+    if hasattr(self,'annot_avg'):
+      self.annot_avg.set_visible(False)
+      del self.annot_avg
 
   def plotsimdat (self):
     # plot the simulation data


### PR DESCRIPTION
If experimental data is shorter than simulation data, the functions
that calculate regular and weighted RMSE will downsample the
simulation data to match the number of samples in experimental data.
However, the start and stop ranges were not aligned. This patch
finds the shortest common range before performing downsampling.