### PR TITLE
BUG: recalculate last step in case it has changed

### DIFF
--- a/hnn_qt5.py
+++ b/hnn_qt5.py
@@ -403,7 +403,8 @@ class RunSimThread (QThread):
 
         # reload opt_params for the last step in case the number of
         # steps was changed by updateoptparams()
-        self.opt_params = dconf['opt_info'][total_steps - 1]
+        final_step = len(dconf['opt_info']) - 1
+        self.opt_params = dconf['opt_info'][final_step]
 
       txt = "Starting optimization step %d/%d"%(step+1,total_steps)
       self.updatewaitsimwin(txt)


### PR DESCRIPTION
During optimization, we update the ranges before running the 4th
and final step with all inputs. If the updating finds that two
inputs are too close to optimize separately, they will be combined
and the total number of optimization steps will decrease. This was
improperly checked before.