### PR TITLE
ENH: support hnn_docker.sh in windows

### DIFF
--- a/installer/docker/troubleshooting.md
+++ b/installer/docker/troubleshooting.md
@@ -2,14 +2,14 @@
 
 Common problems that one might encounter running the HNN docker container are listed below. Some of the links below go to an external site (e.g. MetaCell). If you encounter an issue not listed below, please [open an issue](https://github.com/jonescompneurolab/hnn/issues) on GitHub, including the output with the failed command and any other error messages.
 
-* [Could not connect to any X display](#xdisplay)
-* [Could not create /home//hnn_user/hnn_out/data](#dir)
+Make sure to check the log hnn_docker.log for more verbose error messages that will hint at which of the sections to go to below.
+
+* [Failed to start HNN on any X port](#xdisplay)
+* [Starting HNN fails with 'Drive has not been shared'](#shared)
 * [This computer doesn't have VT-x/AMD-v enabled](#vtx)
 * [Image operating system linux cannot be used on this platform](#image)
 
-<a name="xdisplay"/>
-
-## Failed to start HNN
+# Failed to start HNN
 
 Output from `./docker_hnn.sh start`:
 
@@ -17,7 +17,13 @@ Output from `./docker_hnn.sh start`:
 Starting HNN... failed to start HNN. Please see hnn_docker.log for more details
 ```
 
-In `hnn_docker.log`:
+Check the contents of `hnn_docker.log` to determine which of the following issue applies
+
+<a name="xdisplay"/>
+
+## Failed to start HNN on any X port
+
+`hnn_docker.log` contents:
 ```none
 Starting HNN GUI...
 No protocol specified
@@ -70,35 +76,29 @@ If that doesn't work, troubleshooting steps diverge for each operating system.
 
 If issues persist, please include output from the above commands in a new [GitHub issue](https://github.com/jonescompneurolab/hnn/issues)
 
-<a name="dir"/>
+<a name="shared"/>
 
-## Could not create /home//hnn_user/hnn_out/data
+## Starting HNN fails with 'Drive has not been shared' in hnn_docker.log
 
-```bash
-hnn_container | Trying to start HNN with DISPLAY=host.docker.internal:4
-hnn_container | ERR: could not create /home//hnn_user/hnn_out/data
-hnn_container | HNN failed to start GUI using DISPLAY=host.docker.internal:4
-hnn_container | Failed to start HNN on any X port
+In `hnn_docker.log`:
+
+```node
+Creating hnn_container ... error
+
+ERROR: for hnn_container  Cannot create container for service hnn: b'Drive has not been shared'
+
+ERROR: for hnn  Cannot create container for service hnn: b'Drive has not been shared'
 ```
-
-This can be the result of the shared directory (docker_hnn_out on the host, hnn_out in the container) being owned by root rather than hnn_user. From the host, run the following:
-
-```none
-$ docker-compose up -d
-$ docker exec -ti hnn_container bash
-hnn_user@hnn-container:/home/hnn_user/hnn_source_code$ sudo chown -R hnn_user:hnn_group /home/hnn_user/hnn_out
-hnn_user@hnn-container:/home/hnn_user/hnn_source_code$ exit
-$ docker-compose restart
-```
+This will happen when starting the HNN container for the first time on Windows. When it is starting, there will be a prompt in the lower-right asking you to share the drive C:. Rerun the script to see the prompt again
 
 <a name="vtx"/>
 
-## This computer doesn't have VT-x/AMD-v enabled
+# This computer doesn't have VT-x/AMD-v enabled
 
 [MetaCell documentation link](https://github.com/MetaCell/NetPyNE-UI/wiki/Docker-installation#problem-this-computer-doesnt-have-vt-xamd-v-enabled)
 
 <a name="image"/>
 
-## Image operating system linux cannot be used on this platform
+# Image operating system linux cannot be used on this platform
 
 [MetaCell documentation link](https://github.com/MetaCell/NetPyNE-UI/wiki/Docker-installation#problem-image-operating-system-linux-cannot-be-used-on-this-platform)

--- a/installer/mac/docker-desktop.md
+++ b/installer/mac/docker-desktop.md
@@ -31,7 +31,7 @@
 
         ```bash
         $ git clone https://github.com/jonescompneurolab/hnn.git
-        $ cd hnn/installer/mac
+        $ cd hnn
         ```
 
    * Option 2: Downloading a HNN release
@@ -41,39 +41,17 @@
      3. Open a cmd.exe window and change to the directory part of the extracted HNN release shown below:
 
         ```bash
-        $ cd REPLACE-WITH-FOLDER-EXTRACTED-TO/hnn/installer/mac
+        $ cd REPLACE-WITH-FOLDER-EXTRACTED-TO/hnn
         ```
 
-2. Start the Docker container using the `hnn_docker.sh` script. The output should look something like below.
+2. Start the Docker container using the `hnn_docker.sh` script. For the first time, we will pass the `-u` option in case there were any previous versions of the docker image on your computer. You can omit the `-u` option later
 
     ```bash
-    $ ./hnn_docker.sh start
-    Starting HNN container requested
-
-    Performing pre-checks before starting HNN
-    --------------------------------------
-    Checking if Docker is working... ok
-    Checking if docker-compose is found... ok
-    Checking if XQuartz is installed... ok
-    Checking XQuartz authorization... needs updating
-    Restarting XQuartz... done
-    Starting XQuartz... ok
-    Locating HNN source code... /Users/me/hnn
-
-    Starting HNN
-    --------------------------------------
-    Updating Xauthority file... done
-    Setting up SSH authentication files... done
-    Checking for running HNN container... not found
-    Starting HNN container... done
-    Copying authentication files into container... done
-    Looking up port to connect to HNN container... done
-    Starting HNN...
+    ./hnn_docker.sh -u start
     ```
 
 3. The HNN GUI should show up. Make sure that you can run simulations by clicking the 'Run Simulation' button. This will run a simulation with the default configuration. After it completes, graphs should be displayed in the main window.
-    * If starting the GUI doesn't work, the first thing to check is XQuartz settings (see screenshot above). Then restart your computer and try starting the HNN container again.
-    * Then check the [Docker troubleshooting section](../docker/troubleshooting.md) (also links the bottom of this page)
+    * If the GUI doesn't show up, check the [Docker troubleshooting section](../docker/troubleshooting.md) (also links the bottom of this page)
 4. You can now proceed to running the tutorials at [https://hnn.brown.edu/index.php/tutorials/](https://hnn.brown.edu/index.php/tutorials/) . Some things to note:
    * A directory called "hnn_out" exists both inside the container (at /home/hnn_user/hnn_out) and outside (in the directory set by step 2) that can be used to share files between the container and your host OS.
    * The HNN repository with sample data and parameter files exists at /home/hnn_user/hnn_source_code.
@@ -100,7 +78,7 @@ To pull the latest docker image from Docker Hub, run the `./hnn_docker.sh` scrip
 
 ## Editing files within HNN container
 
-You may want run commands or edit files within the container. To access a command shell in the container, start the container using `./hnn_docker.sh -u start` to start hnn in the background and use [`docker exec`](https://docs.docker.com/engine/reference/commandline/exec/) as shown below:
+You may want run commands or edit files within the container. To access a command shell in the container, start the container using `./hnn_docker.sh  start` to start hnn in the background and use [`docker exec`](https://docs.docker.com/engine/reference/commandline/exec/) as shown below:
 
 ```none
 $ docker exec -ti hnn_container bash
@@ -111,7 +89,7 @@ If you'd like to be able to copy files from the host OS without using the shared
 
 ## Uninstalling HNN
 
-If you want to remove the container and 1.6 GB HNN image, run the following commands from a terminal window. 
+If you want to remove the container and 1.6 GB HNN image, run the following commands from a terminal window.
 
 ```bash
 ./hnn_docker.sh uninstall

--- a/installer/windows/docker-compose.yml
+++ b/installer/windows/docker-compose.yml
@@ -5,11 +5,12 @@ services:
     image: jonescompneurolab/hnn
     container_name: hnn_container
     hostname: hnn-container
+    ports:
+      - "22"
     environment:
-      XAUTHORITY: "/.Xauthority"
+      XAUTHORITY: "/home/hnn_user/.Xauthority"
       DISPLAY: "host.docker.internal:0"
     volumes:
-      - "$HOME/.Xauthority:/.Xauthority"
-      - "/tmp/.X11-unix:/tmp/.X11-unix"
+      - "$HOME/.Xauthority:/home/hnn_user/.Xauthority"
       - "./docker_hnn_out:/home/hnn_user/hnn_out"
-    command: /home/hnn_user/start_hnn.sh
+    command: "sudo /start_ssh.sh"

--- a/installer/windows/docker-desktop.md
+++ b/installer/windows/docker-desktop.md
@@ -28,13 +28,14 @@ There are two related requirements needed for Docker to be able to run HNN in a 
 ## Prerequisite: VcXsrv
 
 1. Download the installer from [https://sourceforge.net/projects/vcxsrv/files/latest/download](https://sourceforge.net/projects/vcxsrv/files/latest/download) (click [here](https://downloads.sourceforge.net/project/vcxsrv/vcxsrv/1.20.1.4/vcxsrv-64.1.20.1.4.installer.exe?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fvcxsrv%2Ffiles%2Fvcxsrv%2F1.20.1.4%2Fvcxsrv-64.1.20.1.4.installer.exe%2Fdownload%3Fuse_mirror%3Dversaweb%26r%3Dhttps%253A%252F%252Fsourceforge.net%252Fprojects%252Fvcxsrv%252Ffiles%252Flatest%252Fdownload&ts=1550243133) for the direct download link for version 64.1.20.1.4)
-2. Run the installer, choosing any installation folder.
-3. Start the XLaunch desktop app from the VcXsrv folder in the start menu.
-4. Choose "Multiple windows" and click 'Next'.
-5. Select "Start no client" and click 'Next'.
-6. **Make sure that "Disable access control" is checked under "Extra settings".** Click 'Next'.
-7. Click "Save configuration" to create a shortcut with the settings we just chose. Click "Finish" and an "X" icon will appear in the lower-right dock signaling that VcXsrv has started.
-8. A message from Windows firewall to allow connections may pop up. If it does, choose options allowing connections to the VcXsrv when connected to both public and private networks.
+2. Run the installer, choosing "C:\Program Files\VcXsrv" as the destination folder. If you choose a different folder the `hnn_docker.sh` script will not be able to launch it automatically. You can start it manually using the procedure below:
+    * (optional) starting VcXsrv manually:
+        1. Start the XLaunch desktop app from the VcXsrv folder in the start menu.
+        2. Choose "Multiple windows" and click 'Next'.
+        3. Select "Start no client" and click 'Next'.
+        4. **Make sure that "Disable access control" is checked under "Extra settings".** Click 'Next'.
+        5. Click "Save configuration" to create a shortcut with the settings we just chose. Click "Finish" and an "X" icon will appear in the lower-right dock signaling that VcXsrv has started.
+        6. A message from Windows firewall to allow connections may pop up. If it does, choose options allowing connections to the VcXsrv when connected to both public and private networks.
 
 ## Prerequisite: Docker Desktop
 
@@ -42,7 +43,7 @@ There are two related requirements needed for Docker to be able to run HNN in a 
 2. Download the installer (requires logging in to your Docker Hub account): [Docker Desktop](https://hub.docker.com/editions/community/docker-ce-desktop-windows)
 3. Run the installer. **DO NOT check** "Use Windows containers instead of Linux containers".
 4. Start the Docker Desktop app from the start menu or desktop (requires logging in to your Docker Hub account). This takes about 30 seconds and the Docker icon will appear in the lower-right dock
-5. When Docker Desktop is initializing, it may prompt you to turn on Hyper-V. 
+5. When Docker Desktop is initializing, it may prompt you to turn on Hyper-V.
    * If you get a message similar to the screen below, click 'Ok' and restart your computer.
 
      <img src="install_pngs/enable_hyperv.png" width="500" />
@@ -51,112 +52,61 @@ There are two related requirements needed for Docker to be able to run HNN in a 
    * If you get the error message shown below, there was a problem turning on hardware support for virtualization, which is required for Docker on Windows. This may be fixable by changing settings in your PC manufacturer's BIOS. See the note on "Hardware virtualization features" under the "Prerequisite: Virtualization support" heading at the top of this page.
 
      <img src="install_pngs/hyperv_error.png" width="500" />
-7. Increase the number of cores that Docker can use (we recommend all cores) by right-clicking on the Docker Desktop icon in the lower-right dock and then clicking "Settings". Choose the "Advanced" tab, and adjust the CPU slider all the way to the right.
 
-    <img src="install_pngs/docker_cores.png" width="400"/>
+7. Reboot your computer after installing Docker
 
-8. Reboot your computer after installing Docker
+## Prerequisite: Git for Windows
+
+1. Download [Git for Windows](https://gitforwindows.org/)
+2. Run the installer, choosing default options
 
 ## Start HNN
 
-1. Verify that VcXsrv (XLaunch application) and Docker are running. VcXsrv will not start automatically after a reboot. The Docker Desktop icon should be present in the lower-right dock. To confirm that Docker is running properly, typing the following in a new cmd.exe window. It should produce output similar to below and not return an error message.
+1. Verify that Docker is running. The Docker Desktop icon should be present in the lower-right dock.
 
-    ```powershell
-    C:\Users\myuser> docker ps
-    CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
+2. Clone the [HNN repo](https://github.com/jonescompneurolab/hnn). Start a 'Git Bash' window from the Start Menu and type the following commands in that window. If you already have a previous version of the repository, bring it up to date with the command `git pull origin master` instead of the `git clone` command below.
+
+    ```bash
+    git clone https://github.com/jonescompneurolab/hnn.git
+    cd hnn
     ```
 
-2. Clone or download the [HNN repo](https://github.com/jonescompneurolab/hnn). **Chose one of the following methods:**
+3. Start the Docker container using the `hnn_docker.sh` script. For the first time, we will pass the `-u` option in case there were any previous versions of the docker image on your computer. You can omit the `-u` option later
 
-   * Option 1: Cloning (requires Git for Windows)
-
-     1. First install [Git for Windows](https://gitforwindows.org/)
-     2. Type the following in a cmd.exe window. If you already have a previous version of the repository, bring it up to date with the command `git pull origin master` instead of the `git clone` command below.
-
-        ```powershell
-        C:\Users\myuser> git clone https://github.com/jonescompneurolab/hnn.git
-        C:\Users\myuser> cd hnn\installer\windows
-        C:\Users\myuser\hnn\installer\windows>
-        ```
-
-   * Option 2: Downloading a HNN release
-
-     1. Download the source code (zip) for our latest HNN release from our [GitHub releases page](https://github.com/jonescompneurolab/hnn/releases)
-     2. Open the .zip file and click "Extract all". Choose any destination folder on your machine.
-     3. Open a cmd.exe window and change to the directory part of the extracted HNN release shown below:
-
-        ```powershell
-        C:\Users\myuser> cd REPLACE-WITH-FOLDER-EXTRACTED-TO\hnn\installer\windows
-        C:\Users\myuser\hnn\installer\windows>
-        ```
-
-3. Start the Docker container. Note: the jonescompneurolab/hnn Docker image will be downloaded from Docker Hub (about 2 GB). The docker-compose command can be used to manage Docker containers described in the specification file docker-compose.yml.
-
-    ```powershell
-    C:\Users\myuser\hnn\installer\windows> docker-compose up
-    Pulling hnn (jonescompneurolab/hnn:)...
-    latest: Pulling from jonescompneurolab/hnn
-    34dce65423d3: Pull complete
-    796769e96d24: Pull complete
-    2a0eada9611d: Pull complete
-    d6830a7cd972: Pull complete
-    ddf2bf28e180: Pull complete
-    3cc50322f9e6: Pull complete
-    413f53de8db6: Pull complete
-    17dc3d1b2db0: Pull complete
-    630b5e60ea64: Pull complete
-    78e9a198ddb9: Pull complete
-    45d8623e986c: Pull complete
-    e32873c7bf4d: Pull complete
-    Creating hnn_container ... done
-    Attaching to hnn_container
+    ```bash
+    ./hnn_docker.sh -u start
     ```
 
-4. If a prompt appears from the lower-right and ask you to share the drive, click 'Share'.
-5. A window will pop up stating "Docker needs to access your computer's filesystem". This is necessary to share data and parameter files that HNN creates with your Windows OS. Enter your Windows login password.
+    * If a prompt appears from the lower-right and ask you to share the drive, click 'Share'. If you miss this on the first time, the script will hang on "Starting HNN..." and eventually fail. Rerun the script to see the prompt again.
+    * A window will pop up stating "Docker needs to access your computer's filesystem". This is necessary to share data and parameter files that HNN creates with your Windows OS. Enter your Windows login password.
 
-   <img src="install_pngs/access_filesystem.png" width="300" />
+        <img src="install_pngs/access_filesystem.png" width="300" />
 
-6. The HNN GUI should show up. Make sure that you can run simulations by clicking the 'Run Simulation' button. This will run a simulation with the default configuration. After it completes, graphs should be displayed in the main window.
-    * If starting the GUI doesn't work the first time, the first thing to check is VcXsrv settings have "Disable access control" (see above). Then restart VcXsrv and try starting the HNN container again.
-    * Then check the [Docker troubleshooting section](../docker/troubleshooting.md) (also links the bottom of this page)
-7. You can now proceed to running the tutorials at [https://hnn.brown.edu/index.php/tutorials/](https://hnn.brown.edu/index.php/tutorials/) . Some things to note:
+4. The HNN GUI should show up. Make sure that you can run simulations by clicking the 'Run Simulation' button. This will run a simulation with the default configuration. After it completes, graphs should be displayed in the main window.
+    * If the GUI doesn't show up, check the [Docker troubleshooting section](../docker/troubleshooting.md) (also links the bottom of this page)
+5. You can now proceed to running the tutorials at [https://hnn.brown.edu/index.php/tutorials/](https://hnn.brown.edu/index.php/tutorials/) . Some things to note:
    * A directory called "hnn_out" exists both inside the container (at /home/hnn_user/hnn_out) and outside (in the directory set by step 2) that can be used to share files between the container and your host OS.
    * The HNN repository with sample data and parameter files exists at /home/hnn_user/hnn_source_code
+6. To quit HNN and shut down container, first press 'Quit' within the GUI. Then run `./hnn_docker.sh stop`.
+
+    ```bash
+    ./hnn_docker.sh stop
+    ```
 
 ## Upgrading to a new version of HNN
 
-1. Verify that XLaunch and Docker are running. Both will not start automatically after a reboot by default.
+To pull the latest docker image from Docker Hub, run the `./hnn_docker.sh` script. After the image has been downloaded, the GUI will be the latest version.
 
-2. You will then need to remove the existing hnn container
-
-    ```powershell
-    C:\Users\myuser> cd hnn\installer\windows
-    C:\Users\myuser\hnn\installer\windows> docker rm -f hnn_container
-    hnn_container
-    ```
-
-3. Then download the latest version of the hnn container image with `docker-compose pull`:
-
-    ```powershell
-    C:\Users\myuser\hnn\installer\windows> docker-compose pull
-    Pulling hnn ... done
-    ```
-
-4. Start the hnn container:
-
-    ```powershell
-    C:\Users\myuser\hnn\installer\windows> docker-compose up
-    Recreating hnn_container ... done
-    Attaching to hnn_container
-    ```
+```bash
+./hnn_docker.sh -u start
+```
 
 ## Editing files within HNN container
 
-You may want run commands or edit files within the container. To access a command shell in the container, start the container using `docker-compose up -d` to start hnn in the background and use [`docker exec`](https://docs.docker.com/engine/reference/commandline/exec/) as shown below:
+You may want run commands or edit files within the container. To access a command shell in the container, start the container using `./hnn_docker.sh  start` to start hnn in the background and use [`docker exec`](https://docs.docker.com/engine/reference/commandline/exec/) as shown below:
 
-```powershell
-C:\Users\myuser> docker exec -ti hnn_container bash
+```none
+$ winpty docker exec -ti hnn_container bash
 hnn_user@hnn-container:/home/hnn_user/hnn_source_code$
 ```
 
@@ -164,12 +114,13 @@ If you'd like to be able to copy files from the host OS without using the shared
 
 ## Uninstalling HNN
 
-If you want to remove the container and 1.6 GB HNN image, run the following commands from a cmd.exe window. You can then remove Docker Desktop using "Add/Remove Programs"
+If you want to remove the container and 1.6 GB HNN image, run the following commands from a terminal window.
 
-```powershell
-C:\Users\myuser> docker rm -f hnn_container
-C:\Users\myuser> docker rmi jonescompneurolab/hnn
+```bash
+./hnn_docker.sh uninstall
 ```
+
+You can then remove Docker Desktop from "Uninstall a program" in the Control Panel.
 
 ## Troubleshooting
 

--- a/installer/windows/docker-toolbox.md
+++ b/installer/windows/docker-toolbox.md
@@ -25,20 +25,21 @@ It is necessary to turn off Hyper-V for using HNN with Docker Toolbox. You may f
 
 1. Download the installer from [https://sourceforge.net/projects/vcxsrv/files/latest/download](https://sourceforge.net/projects/vcxsrv/files/latest/download)
    * Here's the link to the [direct download of version 64.1.20.1.4](https://downloads.sourceforge.net/project/vcxsrv/vcxsrv/1.20.1.4/vcxsrv-64.1.20.1.4.installer.exe?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fvcxsrv%2Ffiles%2Fvcxsrv%2F1.20.1.4%2Fvcxsrv-64.1.20.1.4.installer.exe%2Fdownload%3Fuse_mirror%3Dversaweb%26r%3Dhttps%253A%252F%252Fsourceforge.net%252Fprojects%252Fvcxsrv%252Ffiles%252Flatest%252Fdownload&ts=1550243133)
-2. Run the installer, choosing any installation folder.
-3. Start the XLaunch desktop app from the VcXsrv folder in the start menu.
-4. Choose "Multiple windows" and change "Display number" at '0'. Click 'Next'.
-5. Select "Start no client" and click 'Next'.
-6. Under "Extra settings" make sure that "Disable access control" is checked.
-7. Click "Save configuration" to create a shortcut with the settings we just chose. Click "Finish" and an "X" icon will appear in the lower-right dock signaling that XLaunch has started.
-8. A message from Windows firewall to allow connections may pop up. If it does, choose options allowing connections to VcXsrv (XLaunch) when connected to both public and private networks.
+2. Run the installer, choosing "C:\Program Files\VcXsrv" as the destination folder. If you choose a different folder the `hnn_docker.sh` script will not be able to launch it automatically. You can start it manually using the procedure below:
+    * (optional) starting VcXsrv manually:
+        1. Start the XLaunch desktop app from the VcXsrv folder in the start menu.
+        2. Choose "Multiple windows" and click 'Next'.
+        3. Select "Start no client" and click 'Next'.
+        4. **Make sure that "Disable access control" is checked under "Extra settings".** Click 'Next'.
+        5. Click "Save configuration" to create a shortcut with the settings we just chose. Click "Finish" and an "X" icon will appear in the lower-right dock signaling that VcXsrv has started.
+        6. A message from Windows firewall to allow connections may pop up. If it does, choose options allowing connections to the VcXsrv when connected to both public and private networks.
 
 ## Prerequisite: Docker Toolbox
 
 1. Download the latest installer image (.pkg): [https://github.com/docker/toolbox/releases/](https://github.com/docker/toolbox/releases/)
 2. Run the installer. Click 'Yes' if there's a Windows security prompt requesting to make changes to your device.
 3. Choose any install location.
-4. In "Select Components" check the components "Docker Compose for Windows" and "VirtualBox". "Kitematic" is not needed. Click 'Next'.
+4. In "Select Components" check the components "Docker Compose for Windows" and "VirtualBox" **and "Git for Windows"**. "Kitematic" is not needed. Click 'Next'.
 5. In "Select Additional Tasks", make sure to **check "Add docker binaries to PATH"**. Click 'Next'.
 6. Choose the default for the other options and click 'Install'.
 7. When the installer has finished, select the option to "Open program shortcuts in File Explorer". Click "Finish".
@@ -116,110 +117,57 @@ If you run into problems, check the official Docker Toolbox documentation: [Dock
 
 ## Start HNN
 
-1. Verify that VcXsrv (XLaunch application) and Docker are running. Both will not start automatically after a reboot. VcXsrv (XLaunch application) will show an "X" icon in the Windows dock when running. The Docker Desktop icon should be present in the lower-right dock. To confirm that Docker is running properly, run the `docker ps` command, which return output similar to below and not return an error message.
+1. From a "Docker Quickstart Terminal", clone the [HNN repo](https://github.com/jonescompneurolab/hnn). If you already have a previous version of the repository, bring it up to date with the command `git pull origin master` instead of the `git clone` command below.
 
     ```bash
-    $ docker ps
-    CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
+    cd ~
+    git clone https://github.com/jonescompneurolab/hnn.git
+    cd hnn
     ```
 
-2. Clone or download the [HNN repo](https://github.com/jonescompneurolab/hnn). **Chose one of the following methods:**
-
-   * Option 1: Downloading a HNN release
-
-     1. Download the source code (zip) for our latest HNN release from our [GitHub releases page](https://github.com/jonescompneurolab/hnn/releases)
-     2. Open the .zip file and click "Extract all". Choose any destination folder on your machine.
-     3. In the terminal, change to the directory part of the extracted HNN release shown below:
-
-        ```bash
-        $ cd REPLACE-WITH-FOLDER-EXTRACTED-TO\hnn\installer\windows
-        ```
-
-   * Option 2: Cloning (requires Git for Windows)
-
-     1. If you didn't install Git for Windows above (not required), download the installer at [Git for Windows](https://gitforwindows.org/)
-     2. If you already have a previous version of the repository, bring it up to date with the command `git pull origin master` instead of the `git clone` command below.
-
-        ```bash
-        $ cd ~
-        $ git clone https://github.com/jonescompneurolab/hnn.git
-        $ cd hnn/installer/windows
-        ```
-
-3. Start the Docker container. Note: the jonescompneurolab/hnn Docker image will be downloaded from Docker Hub (about 2 GB). The docker-compose command can be used to manage Docker containers described in the specification file docker-compose.yml.
+2. Start the Docker container using the `hnn_docker.sh` script. For the first time, we will pass the `-u` option in case there were any previous versions of the docker image on your computer. You can omit the `-u` option later
 
     ```bash
-    $ docker-compose run -e "DISPLAY=192.168.99.1:0" --name hnn_container hnn
-    Creating network "windows_default" with the default driver
-    Pulling hnn (jonescompneurolab/hnn:)...
-    latest: Pulling from jonescompneurolab/hnn
-    34dce65423d3: Already exists
-    796769e96d24: Already exists
-    2a0eada9611d: Already exists
-    d6830a7cd972: Already exists
-    ddf2bf28e180: Already exists
-    77bf1279b29f: Pull complete
-    6c8ddf82616f: Pull complete
-    a991616934ba: Pull complete
-    2cece6240c19: Pull complete
-    df826e7d26b9: Pull complete
-    824d51cbc89d: Pull complete
-    0d16f27c744b: Pull complete
-    Digest: sha256:0c27e2027828d2510a8867773562bbc966c509f45c9921cc2d1973c575d327b3
-    Status: Downloaded newer image for jonescompneurolab/hnn:latest
+    ./hnn_docker.sh -u start
     ```
 
-4. A window will pop up stating "Docker needs to access your computer's filesystem". This is necessary to share data and parameter files that HNN creates with your Windows OS. Enter your Windows login password.
+    * A window may pop up stating "Docker needs to access your computer's filesystem". This is necessary to share data and parameter files that HNN creates with your Windows OS. Enter your Windows login password.
 
-    <img src="install_pngs/access_filesystem.png" width="300" />
+        <img src="install_pngs/access_filesystem.png" width="300" />
 
-5. The HNN GUI should show up. Make sure that you can run simulations by clicking the 'Run Simulation' button. This will run a simulation with the default configuration. After it completes, graphs should be displayed in the main window.
-    * If starting the GUI doesn't work the first time, the first thing to check is VcXsrv settings have "Disable access control" (see above). Then restart VcXsrv and try starting the HNN container again.
-6. You can now proceed to running the tutorials at [https://hnn.brown.edu/index.php/tutorials/](https://hnn.brown.edu/index.php/tutorials/) . Some things to note:
+3. The HNN GUI should show up. Make sure that you can run simulations by clicking the 'Run Simulation' button. This will run a simulation with the default configuration. After it completes, graphs should be displayed in the main window.
+    * If the GUI doesn't show up, check the [Docker troubleshooting section](../docker/troubleshooting.md) (also links the bottom of this page)
+4. You can now proceed to running the tutorials at [https://hnn.brown.edu/index.php/tutorials/](https://hnn.brown.edu/index.php/tutorials/) . Some things to note:
    * A directory called "hnn_out" exists both inside the container (at /home/hnn_user/hnn_out) and outside (in the directory set by step 2) that can be used to share files between the container and your host OS.
    * The HNN repository with sample data and parameter files exists at /home/hnn_user/hnn_source_code
+5. To quit HNN and shut down container, first press 'Quit' within the GUI. Then run `./hnn_docker.sh stop`.
+
+    ```bash
+    ./hnn_docker.sh stop
+    ```
 
 ## Stopping Docker Toolbox VM
 
 The Docker Toolbox VM will remain running the background using some resources. If you are not using HNN, you can shut down the VM by the following command:
 
 ```bash
-$ docker-machine stop
+docker-machine stop
 ```
 
 ## Upgrading to a new version of HNN
 
-1. Verify that XLaunch and Docker are running. Both will not start automatically after a reboot by default.
+To pull the latest docker image from Docker Hub, run the `./hnn_docker.sh` script. After the image has been downloaded, the GUI will be the latest version.
 
-2. You will then need to remove the existing hnn container
-
-    ```bash
-    $ cd hnn/installer/mac
-    $ docker rm -f hnn_container
-    hnn_container
-    ```
-
-3. Then download the latest version of the hnn container image with `docker-compose pull`:
-
-    ```bash
-    $ docker-compose pull
-    Pulling hnn ... done
-    ```
-
-4. Start the hnn container:
-
-    ```bash
-    $ docker-compose up
-    Recreating hnn_container ... done
-    Attaching to hnn_container
-    ```
+```bash
+./hnn_docker.sh -u start
+```
 
 ## Editing files within HNN container
 
-You may want run commands or edit files within the container. To access a command shell in the container, start the container with `docker-compose run -e "DISPLAY=192.168.99.1:0" --name hnn_container hnn` in one terminal window and open another terminal to use [`docker exec`](https://docs.docker.com/engine/reference/commandline/exec/) as shown below:
+You may want run commands or edit files within the container. To access a command shell in the container, start the container using `./hnn_docker.sh  start` to start hnn in the background and use [`docker exec`](https://docs.docker.com/engine/reference/commandline/exec/) as shown below:
 
 ```none
-$ docker exec -ti hnn_container bash
+$ winpty docker exec -ti hnn_container bash
 hnn_user@hnn-container:/home/hnn_user/hnn_source_code$
 ```
 
@@ -227,12 +175,15 @@ If you'd like to be able to copy files from the host OS without using the shared
 
 ## Uninstalling HNN
 
-If you want to remove the container and 1.6 GB HNN image, run the following commands from a quickstart terminal window. You can then remove Docker Desktop using "Add/Remove Programs"
+1. If you want to remove the container and 1.6 GB HNN image, run the following commands from a terminal window.
 
-```bash
-$ docker rm -f windows_hnn_1
-$ docker rmi jonescompneurolab/hnn
-```
+    ```bash
+    ./hnn_docker.sh uninstall
+    ```
+
+2. You can then remove Docker Toolbox from "Uninstall a program" in the Control Panel.
+
+3. You can remove Virtualbox as well if you no longer need it to run virtual machines
 
 ## Troubleshooting
 


### PR DESCRIPTION
This commit finishes support for hnn_docker.sh in Windows. It
changes the install procedure to require Git for Windows and
commands are run from 'Git Bash' instead of cmd.exe.

Fixes #125