### PR TITLE
BUG: fix issue not completing 25 trials

### DIFF
--- a/hnn_qt5.py
+++ b/hnn_qt5.py
@@ -274,14 +274,18 @@ class RunSimThread (QThread):
       self.proc = Popen(cmdargs,stdout=PIPE,stderr=PIPE,cwd=os.getcwd(),universal_newlines=True)
 
   def get_proc_stream (self, stream, print_to_console=False):
-    for line in iter(stream.readline, ""):
-      if print_to_console:
-        print(line.strip())
-      try: # see https://stackoverflow.com/questions/2104779/qobject-qplaintextedit-multithreading-issues
-        self.updatewaitsimwin(line.strip()) # sends a pyqtsignal to waitsimwin, which updates its textedit
-      except:
-        if debug: print('RunSimThread updatewaitsimwin exception...')
-        pass # catch exception in case anything else goes wrong
+    try:
+      for line in iter(stream.readline, ""):
+        if print_to_console:
+          print(line.strip())
+        try: # see https://stackoverflow.com/questions/2104779/qobject-qplaintextedit-multithreading-issues
+          self.updatewaitsimwin(line.strip()) # sends a pyqtsignal to waitsimwin, which updates its textedit
+        except:
+          if debug: print('RunSimThread updatewaitsimwin exception...')
+          pass # catch exception in case anything else goes wrong
+    except ValueError:
+      # if process is killed and stream.readline() gives I/O error
+      pass
     stream.close()
 
   # run sim command via mpi, then delete the temp file.

--- a/installer/docker/Dockerfile
+++ b/installer/docker/Dockerfile
@@ -39,7 +39,8 @@ RUN echo '# these lines define global session variables for HNN' >> ~/.bashrc &&
     echo 'export PATH=$PATH:/home/hnn_user/nrn/build/$CPU/bin' >> ~/.bashrc && \
     echo 'export PYTHONPATH=/home/hnn_user/nrn/build/lib/python' >> ~/.bashrc && \
     echo 'export OMPI_MCA_mpi_warn_on_fork=0' >> ~/.bashrc && \
-    echo 'export OMPI_MCA_btl_openib_allow_ib=1' >> ~/.bashrc
+    echo 'export OMPI_MCA_btl_openib_allow_ib=1' >> ~/.bashrc && \
+    echo 'export OMPI_MCA_btl_vader_single_copy_mechanism=none' >> ~/.bashrc
 
 # run sudo to get rid of message on first login about using sudo
 RUN sudo -l
@@ -62,6 +63,7 @@ RUN sudo apt-get update && \
     mkdir nrn && \
     cd nrn && \
     git clone https://github.com/neuronsimulator/nrn src && \
+    git checkout 7.7 && \
     cd /home/hnn_user/nrn/src && \
     ./build.sh && \
     ./configure --with-nrnpython=python3 --with-paranrn --disable-rx3d \
@@ -102,8 +104,6 @@ RUN sudo chown hnn_user:hnn_group /home/hnn_user/start_hnn.sh && \
     sudo chmod +x /start_ssh.sh
 
 RUN sudo sed 's/AcceptEnv.*/AcceptEnv LANG LC_* DISPLAY/' -i /etc/ssh/sshd_config
-
-CMD sleep infinity
 
 # if users open up a shell, they should go to the hnn repo checkout
 WORKDIR /home/hnn_user/hnn_source_code


### PR DESCRIPTION
Also pegs NEURON in container to branch 7.7

Setting OMPI_MCA_btl_vader_single_copy_mechanism=none was necessary
for NEURON simulations to finish correctly. If a lot of simulations
(e.g. 25) are run, then NEURON would hang, results wouldn't display
in HNN, and 'Stop Simulations' would have to be pressed.
https://github.com/open-mpi/ompi/issues/4948