### PR TITLE
ENH: set maximum window height for dual monitors

### DIFF
--- a/gutils.py
+++ b/gutils.py
@@ -31,6 +31,9 @@ def scalegeom (width, height):
   screenwidth, screenheight = getscreengeom()
   widthnew = int((screenwidth / devwidth) * width)
   heightnew = int((screenheight / devheight) * height)
+  if widthnew > 1000 or heightnew > 850:
+    widthnew = 1000
+    heightnew = 850
   return widthnew, heightnew
 
 # set dialog's position (x,y) and rescale geometry based on original width and height and development resolution
@@ -40,13 +43,13 @@ def setscalegeom (dlg, x, y, origw, origh):
   dlg.setGeometry(x, y, int(nw), int(nh))
   return int(nw), int(nh)
 
-# set dialog in center of screen and rescale size based on original width and height and development resolution
+# set dialog in center of screen width and rescale size based on original width and height and development resolution
 def setscalegeomcenter (dlg, origw, origh):
   nw, nh = scalegeom(origw, origh)
   # print('origw,origh:',origw, origh,'nw,nh:',nw, nh)
   sw, sh = getscreengeom()
   x = (sw-nw)/2
-  y = (sh-nh)/2
+  y = 0
   dlg.setGeometry(x, y, int(nw), int(nh))
   return int(nw), int(nh)
 


### PR DESCRIPTION
Also orient main GUI window at the top of the display, centered
left to right.