### PR TITLE
ENH: handle exceptions when loading files

### DIFF
--- a/clidefs.py
+++ b/clidefs.py
@@ -1136,7 +1136,12 @@ def exec_phaselock(ddata, opts):
             tmp_array_dpl.append(dp)
 
             # Load extinput data, do stuff, and store it
-            extinput = spikefn.ExtInputs(f_spk, f_param)
+            try:
+                extinput = spikefn.ExtInputs(f_spk, f_param)
+            except ValueError:
+                print("Error: could not load spike timings from %s" % f_spk)
+                return
+
             extinput.add_delay_times()
             extinput.get_envelope(dpl.t, feed='dist', bins=150)
             inputs, t = extinput.truncate_ext('env', p['t_interval'])

--- a/dipolefn.py
+++ b/dipolefn.py
@@ -592,7 +592,13 @@ def pdipole_with_hist(f_dpl, f_spk, dfig, f_param, key_types, plot_dict):
   # set new xlim based on dipole plot
   xlim_new = f.ax['dipole'].get_xlim()
   # Get extinput data and account for delays
-  extinputs = spikefn.ExtInputs(f_spk, f_param)
+  try:
+    extinputs = spikefn.ExtInputs(f_spk, f_param)
+  except ValueError:
+    print("Error: could not load spike timings from %s" % f_spk)
+    f.close()
+    return
+
   extinputs.add_delay_times()
   # set number of bins (150 bins per 1000ms)
   bins = ceil(150. * (xlim_new[1] - xlim_new[0]) / 1000.) # bins needs to be an int

--- a/pspec.py
+++ b/pspec.py
@@ -122,7 +122,13 @@ def pspec_with_hist(f_spec, f_dpl, f_spk, dfig, f_param, key_types, xlim=None, y
   # # Account for possible delays
   # s_dict = spikefn.add_delay_times(s_dict, p_dict)
   # Get extinput data and account for delays
-  extinputs = spikefn.ExtInputs(f_spk, f_param)
+  try:
+    extinputs = spikefn.ExtInputs(f_spk, f_param)
+  except ValueError:
+    print("Error: could not load spike timings from %s" % f_spk)
+    f.close()
+    return
+
   extinputs.add_delay_times()
   extinputs.get_envelope(dpl.t, feed='dist')
   # set number of bins (150 bins per 1000ms)

--- a/spikefn.py
+++ b/spikefn.py
@@ -62,7 +62,10 @@ class ExtInputs (Spikes):
   # class for external inputs - extracts gids and times
   def __init__ (self, fspk, fparam, evoked=False):
     # load gid and param dicts
-    self.gid_dict, self.p_dict = paramrw.read(fparam)
+    try:
+      self.gid_dict, self.p_dict = paramrw.read(fparam)
+    except OSError:
+      raise ValueError
     self.evoked = evoked
     # parse evoked prox and dist input gids from gid_dict
     # print('getting evokedinput gids')
@@ -150,7 +153,18 @@ class ExtInputs (Spikes):
 
   def __get_extinput_times (self, fspk):
     # load all spike times from file
-    s_all = np.loadtxt(open(fspk, 'rb'))
+    s_all = []
+    try:
+      s_all = np.loadtxt(open(fspk, 'rb'))
+    except OSError:
+      print('Warning: could not read file:', fspk)
+    except ValueError:
+      print('Warning: error reading data from:', fspk)
+
+    if len(s_all) == 0:
+      # couldn't read spike times
+      raise ValueError
+
     inputs = {k:np.array([]) for k in ['prox','dist','evprox','evdist','pois']}
     if self.gid_prox is not None: inputs['prox'] = self.get_times(self.gid_prox,s_all)
     if self.gid_dist is not None: inputs['dist'] = self.get_times(self.gid_dist,s_all)

--- a/visrast.py
+++ b/visrast.py
@@ -49,7 +49,11 @@ for i in range(len(sys.argv)):
     PoissonInputs = paramrw.usingPoissonInputs(paramf)
     outparamf = os.path.join(dconf['datdir'],paramf.split('.param')[0].split(os.path.sep)[-1],'param.txt')
 
-extinputs = spikefn.ExtInputs(spkpath, outparamf)
+try:
+  extinputs = spikefn.ExtInputs(spkpath, outparamf)
+except ValueError:
+  print("Error: could not load spike timings from %s" % spkpath)
+
 extinputs.add_delay_times()
 
 alldat = {}
@@ -211,7 +215,11 @@ class SpikeCanvas (FigureCanvas):
     if idx in alldat: return
     alldat[idx] = {}
     if idx == 0:
-      extinputs = spikefn.ExtInputs(spkpath, outparamf)
+      try:
+        extinputs = spikefn.ExtInputs(spkpath, outparamf)
+      except ValueError:
+        print("Error: could not load spike timings from %s" % spkpath)
+        return
       extinputs.add_delay_times()
       dspk,haveinputs,dhist = getdspk(spkpath)
       alldat[idx]['dspk'] = dspk
@@ -221,7 +229,11 @@ class SpikeCanvas (FigureCanvas):
     else:
       spkpathtrial = os.path.join(dconf['datdir'],paramf.split('.param')[0].split(os.path.sep)[-1],'spk_'+str(self.index-1)+'.txt') 
       dspktrial,haveinputs,dhisttrial = getdspk(spkpathtrial) # show spikes from first trial
-      extinputs = spikefn.ExtInputs(spkpathtrial, outparamf)
+      try:
+        extinputs = spikefn.ExtInputs(spkpathtrial, outparamf)
+      except ValueError:
+        print("Error: could not load spike timings from %s" % spkpath)
+        return
       extinputs.add_delay_times()
       alldat[idx]['dspk'] = dspktrial
       alldat[idx]['haveinputs'] = haveinputs


### PR DESCRIPTION
Do not raise a fatal exception when trying to read data files. Just
handle the exception and plot as much as possible with the loaded
data (if any).

New readtxt function in simdat.py and revamped updatedat that
uses readtxt

Fixes #115