### PR TITLE
BUG: fix saving figures

### DIFF
--- a/specfn.py
+++ b/specfn.py
@@ -365,7 +365,7 @@ class Spec():
 
     # parses the specific data file
     def __parse_f(self, fspec):
-        data_spec = np.load(fspec)
+        data_spec = np.load(fspec, allow_pickle=True)
 
         if self.dtype == 'dpl':
             self.spec = {}


### PR DESCRIPTION
Because of a numpy change, the parameter allow_pickle needs to be
explicitly set to True.
https://docs.scipy.org/doc/numpy/reference/generated/numpy.load.html

Fixes #129