### PR TITLE
Update default hnn_out path in docker

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -136,7 +136,10 @@ def readconf (fn="hnn.cfg",nohomeout=False):
     if not safemkdir(dbase): sys.exit(1) # check existence of base hnn output dir
   else:
     if d['homeout']: # user home directory for output
-      dbase = os.path.join(os.path.expanduser('~'),'hnn_out') # user home directory
+      if 'SYSTEM_USER_DIR' in os.environ:
+        dbase = os.path.join(os.environ["SYSTEM_USER_DIR"],'hnn_out') # user home directory
+      else:
+        dbase = os.path.join(os.path.expanduser('~'),'hnn_out') # user home directory
       if not safemkdir(dbase): sys.exit(1) # check existence of base hnn output dir
     else: # cwd for output
       dbase = os.getcwd() # use os.getcwd instead for better compatability with NSG

--- a/installer/aws/README.md
+++ b/installer/aws/README.md
@@ -32,7 +32,7 @@ This guide describes running HNN on Amazon Web Services (AWS). An image containi
    hnn
    ```
 
-9. You can now proceed to the tutorials at [https://hnn.brown.edu/index.php/tutorials/](https://hnn.brown.edu/index.php/tutorials/). Some things to note:
+4. You can now proceed to the tutorials at [https://hnn.brown.edu/index.php/tutorials/](https://hnn.brown.edu/index.php/tutorials/). Some things to note:
    * The directory `/home/ubuntu/hnn_out` is where the results from your simulations (data and param files) will be stored.
    * The "Model Visualization" button will not work on the AWS virtualization hardware.
 

--- a/installer/centos/README.md
+++ b/installer/centos/README.md
@@ -66,8 +66,7 @@ Open a bash terminal and run these commands (from [Docker Compose installation](
 3. The HNN GUI should show up. Make sure that you can run simulations by clicking the 'Run Simulation' button. This will run a simulation with the default configuration. After it completes, graphs should be displayed in the main window.
     - If the GUI doesn't show up, check the [Docker troubleshooting section](../docker/troubleshooting.md) (also links the bottom of this page). It may be necessary to run the `xhost +local:docker` command to open up permissions to display the GUI on your local machine.
 4. You can now proceed to running the tutorials at [https://hnn.brown.edu/index.php/tutorials/](https://hnn.brown.edu/index.php/tutorials/) . Some things to note:
-    - A directory called "hnn_out" exists both inside the container (at /home/hnn_user/hnn_out) and outside (in the directory set by step 2) that can be used to share files between the container and your host OS.
-    - The HNN repository with sample data and parameter files exists at /home/hnn_user/hnn_source_code
+    - A subdirectory called "hnn_out" is created in your home directory and is where simulation results and parameter files will be saved.
 5. To quit HNN and shut down container, first press 'Quit' within the GUI. Then run `./hnn_docker.sh stop`.
 
     ```bash

--- a/installer/docker/Dockerfile
+++ b/installer/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM caldweba/opengl-docker
 
+EXPOSE 22
+
 # avoid questions from debconf
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -8,30 +10,50 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN groupadd hnn_group && useradd -m -b /home/ -g hnn_group hnn_user && \
     adduser hnn_user sudo && \
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
-    chown -R hnn_user:hnn_group /home/hnn_user && \
     chsh -s /bin/bash hnn_user
+
+# Qt prerequisites packages
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        libfontconfig libxext6 libx11-xcb1 libxcb-glx0 \
+        libegl1 && \
+    apt-get clean
+
+# base prerequisites packages
+RUN apt-get install --no-install-recommends -y \
+        python3-pip python3-setuptools openssh-server openmpi-bin lsof && \
+    apt-get clean
 
 COPY date_base_install.sh /usr/local/bin
 RUN chmod +x /usr/local/bin/date_base_install.sh && \
     /usr/local/bin/date_base_install.sh
 
-RUN apt-get update && apt-get install -y openssh-server
 RUN mkdir /var/run/sshd
 
 # SSH login fix. Otherwise user is kicked off after login
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
+RUN sed 's/AcceptEnv.*/AcceptEnv LANG LC_* DISPLAY/' -i /etc/ssh/sshd_config
 
-EXPOSE 22
+# if users open up a shell, they should go to the hnn repo checkout
+WORKDIR /home/hnn_user/hnn_source_code
+RUN chown -R hnn_user:hnn_group /home/hnn_user
 
 USER hnn_user
 
-RUN mkdir /home/hnn_user/hnn_out && \
-    mkdir /home/hnn_user/.ssh
+# get HNN python dependencies
+# python3-dev and gcc needed for building psutil
+RUN sudo pip3 install --no-cache-dir --upgrade pip && \
+    sudo apt-get install --no-install-recommends -y \
+        gcc python3-dev && \
+    pip install --no-cache-dir --user matplotlib PyOpenGL \
+        pyqt5 pyqtgraph scipy numpy nlopt psutil && \
+    sudo apt-get -y remove --purge \
+        gcc python3-dev && \
+    sudo apt-get autoremove -y --purge && \
+    sudo apt-get clean
 
-# allow user to specify architecture if different than x86_64
-ARG CPU=x86_64
-# supply the path NEURON binaries for building hnn
-ENV PATH=${PATH}:/home/hnn_user/nrn/build/$CPU/bin
+RUN mkdir /home/hnn_user/hnn_out \
+          /home/hnn_user/.ssh
 
 # use environment variables from hnn_envs
 RUN echo 'source /home/hnn_user/hnn_envs' >> ~/.bashrc
@@ -41,38 +63,7 @@ RUN sudo -l
 
 CMD /home/hnn_user/start_hnn.sh
 
-# compile NEURON, only temporarily installing packages for building
-RUN sudo apt-get update && \
-    sudo apt-get install -y git python3-dev python3-pip python3-psutil \
-                       bison flex automake libtool libncurses-dev zlib1g-dev \
-                       libopenmpi-dev openmpi-bin libqt5core5a libllvm6.0 \
-                       libxaw7 libxmu6 libxpm4 libxcb-glx0 \
-                       libxkbcommon-x11-0 libfontconfig libx11-xcb1 libxrender1 \
-                       git vim iputils-ping net-tools iproute2 nano sudo \
-                       telnet language-pack-en-base && \
-    sudo pip3 install pip --upgrade && \
-    sudo pip install PyOpenGL matplotlib pyqt5 pyqtgraph scipy numpy nlopt && \
-    sudo rm -rf /home/hnn_user/.cache && \
-    cd /home/hnn_user/ && \
-    mkdir nrn && \
-    cd nrn && \
-    git clone https://github.com/neuronsimulator/nrn src && \
-    cd /home/hnn_user/nrn/src && \
-    git checkout 7.7 && \
-    ./build.sh && \
-    ./configure --with-nrnpython=python3 --with-paranrn --disable-rx3d \
-      --without-iv --without-nrnoc-x11 --with-mpi \
-      --prefix=/home/hnn_user/nrn/build && \
-    make -j4 && \
-    make install -j4 && \
-    cd src/nrnpython && \
-    python3 setup.py install --user && \
-    cd /home/hnn_user/nrn/ && \
-    rm -rf src && \
-    sudo apt-get -y remove --purge bison flex python3-dev zlib1g-dev && \
-    sudo apt-get autoremove -y --purge && \
-    sudo apt-get clean
-
+# use args to avoid caching
 ARG BUILD_DATE
 ARG VCS_REF
 ARG VCS_TAG
@@ -83,11 +74,30 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.schema-version=$VCS_TAG
 
-RUN cd /home/hnn_user && \
+# install NEURON
+RUN wget -q https://neuron.yale.edu/ftp/neuron/versions/v7.7/nrn-7.7.x86_64-linux.deb -O /tmp/nrn.deb && \
+    sudo dpkg -i /tmp/nrn.deb && \
+    rm -f /tmp/nrn.deb
+
+# install HNN
+RUN sudo apt-get install --no-install-recommends -y \
+        make gcc libc6-dev libtinfo-dev libncurses-dev \
+        libx11-dev libreadline-dev && \
+    cd /home/hnn_user && \
     git clone https://github.com/jonescompneurolab/hnn.git \
-      --single-branch --branch $SOURCE_BRANCH hnn_source_code && \
+        --depth 1 --single-branch --branch $SOURCE_BRANCH hnn_source_code && \
     cd hnn_source_code && \
-    make
+    make && \
+    sudo apt-get -y remove --purge \
+        make gcc libc6-dev libtinfo-dev libncurses-dev \
+        libx11-dev libreadline-dev && \
+    sudo apt-get autoremove -y --purge && \
+    sudo apt-get clean
+
+# NEURON runtime prerequisites
+RUN sudo apt-get install --no-install-recommends -y \
+        libncurses5 libreadline5 libdbus-1-3 libopenmpi-dev && \
+    sudo apt-get clean
 
 # copy the start script into the container
 COPY start_hnn.sh /home/hnn_user/
@@ -98,8 +108,3 @@ RUN sudo chown hnn_user:hnn_group /home/hnn_user/start_hnn.sh && \
     sudo chown root:root /start_ssh.sh && \
     sudo chmod +x /start_ssh.sh && \
     sudo chown hnn_user:hnn_group /home/hnn_user/hnn_envs
-
-RUN sudo sed 's/AcceptEnv.*/AcceptEnv LANG LC_* DISPLAY/' -i /etc/ssh/sshd_config
-
-# if users open up a shell, they should go to the hnn repo checkout
-WORKDIR /home/hnn_user/hnn_source_code

--- a/installer/docker/README.md
+++ b/installer/docker/README.md
@@ -21,7 +21,7 @@ The BUILD_DATE argument is important to build the container with the latest HNN 
 
 ```bash
 cd hnn/installer/docker
-docker build --tag jonescompneurolab/hnn --build-arg SOURCE_BRANCH=master BUILD_DATE=$(date +%s) .
+docker build --tag jonescompneurolab/hnn --build-arg SOURCE_BRANCH=master --build-arg BUILD_DATE=$(date +%s) .
 ```
 
 ## Running HNN container without docker-compose

--- a/installer/docker/docker-compose.yml
+++ b/installer/docker/docker-compose.yml
@@ -7,10 +7,10 @@ services:
     hostname: hnn-container
     environment:
       XAUTHORITY: "/home/hnn_user/.Xauthority"
-      DISPLAY: ":0"
+      DISPLAY: $DISPLAY
+      SYSTEM_USER_DIR: $HOME
     volumes:
       - "$XAUTHORITY:/home/hnn_user/.Xauthority"
       - "/tmp/.X11-unix:/tmp/.X11-unix"
-      - "./docker_hnn_out:/home/hnn_user/hnn_out"
-      - "../../shared:/home/hnn_user/shared"
+      - "$HOME:$HOME"
     command: /home/hnn_user/start_hnn.sh

--- a/installer/docker/hnn_envs
+++ b/installer/docker/hnn_envs
@@ -1,5 +1,5 @@
-export PATH=$PATH:/home/hnn_user/nrn/build/x86_64/bin
-export PYTHONPATH=/home/hnn_user/nrn/build/lib/python
+export PYTHONPATH=/usr/local/nrn/lib/python
 export OMPI_MCA_mpi_warn_on_fork=0
 export OMPI_MCA_btl_openib_allow_ib=1
 export OMPI_MCA_btl_vader_single_copy_mechanism=none
+export OMPI_MCA_btl_base_warn_component_unused=0

--- a/installer/mac/docker-compose.yml
+++ b/installer/mac/docker-compose.yml
@@ -10,8 +10,8 @@ services:
     environment:
       XAUTHORITY: "/home/hnn_user/.Xauthority"
       DISPLAY: "host.docker.internal:0"
+      SYSTEM_USER_DIR: $HOME
     volumes:
       - "$XAUTHORITY:/home/hnn_user/.Xauthority"
-      - "./docker_hnn_out:/home/hnn_user/hnn_out"
-      - "../../shared:/home/hnn_user/shared"
+      - "$HOME:$HOME"
     command: "sudo /start_ssh.sh"

--- a/installer/mac/docker-desktop.md
+++ b/installer/mac/docker-desktop.md
@@ -56,8 +56,7 @@
 3. The HNN GUI should show up. Make sure that you can run simulations by clicking the 'Run Simulation' button. This will run a simulation with the default configuration. After it completes, graphs should be displayed in the main window.
     * If the GUI doesn't show up, check the [Docker troubleshooting section](../docker/troubleshooting.md) (also links the bottom of this page)
 4. You can now proceed to running the tutorials at [https://hnn.brown.edu/index.php/tutorials/](https://hnn.brown.edu/index.php/tutorials/) . Some things to note:
-   * A directory called "hnn_out" exists both inside the container (at /home/hnn_user/hnn_out) and outside (in the directory set by step 2) that can be used to share files between the container and your host OS.
-   * The HNN repository with sample data and parameter files exists at /home/hnn_user/hnn_source_code.
+    * A subdirectory called "hnn_out" is created in your home directory and is where simulation results and parameter files will be saved.
 5. To quit HNN and shut down container, first press 'Quit' within the GUI. Then run `./hnn_docker.sh stop`.
 
     ```bash

--- a/installer/mac/docker-toolbox.md
+++ b/installer/mac/docker-toolbox.md
@@ -100,8 +100,7 @@ If you run into problems, check the official Docker Toolbox documentation: [Dock
 3. The HNN GUI should show up. Make sure that you can run simulations by clicking the 'Run Simulation' button. This will run a simulation with the default configuration. After it completes, graphs should be displayed in the main window.
     * If the GUI doesn't show up, check the [Docker troubleshooting section](../docker/troubleshooting.md) (also links the bottom of this page)
 4. You can now proceed to running the tutorials at [https://hnn.brown.edu/index.php/tutorials/](https://hnn.brown.edu/index.php/tutorials/) . Some things to note:
-   * A directory called "hnn_out" exists both inside the container (at /home/hnn_user/hnn_out) and outside (in the directory set by step 2) that can be used to share files between the container and your host OS.
-   * The HNN repository with sample data and parameter files exists at /home/hnn_user/hnn_source_code.
+    * A subdirectory called "hnn_out" is created in your home directory and is where simulation results and parameter files will be saved.
 5. To quit HNN and shut down container, first press 'Quit' within the GUI. Then run `./hnn_docker.sh stop`.
 
     ```bash

--- a/installer/mac/native_install.md
+++ b/installer/mac/native_install.md
@@ -174,9 +174,9 @@ sudo installer -pkg /tmp/nrn-7.7.x86_64-osx.pkg -allowUntrusted -target /
 <img src="install_pngs/orterun_firewall.png" width="400" />
 
 4. You can now proceed to running the tutorials at https://hnn.brown.edu/index.php/tutorials/ . Some things to note:
-   * A directory called "hnn_out" exists in your home directory where the results from your simulations (data and param files) will be stored.
+    - A directory called "hnn_out" exists in your home directory where the results from your simulations (data and param files) will be stored.
 
-# Troubleshooting
+## Troubleshooting
 
 For Mac OS specific issues: please see the [Mac OS troubleshooting page](troubleshooting.md)
 

--- a/installer/ubuntu/README.md
+++ b/installer/ubuntu/README.md
@@ -63,10 +63,9 @@ Open a bash terminal and run these commands (from [Docker Compose installation](
     ```
 
 3. The HNN GUI should show up. Make sure that you can run simulations by clicking the 'Run Simulation' button. This will run a simulation with the default configuration. After it completes, graphs should be displayed in the main window.
-    * If the GUI doesn't show up, check the [Docker troubleshooting section](../docker/troubleshooting.md) (also links the bottom of this page). It may be necessary to run the `xhost +local:docker` command to open up permissions to display the GUI on your local machine.
+    - If the GUI doesn't show up, check the [Docker troubleshooting section](../docker/troubleshooting.md) (also links the bottom of this page). It may be necessary to run the `xhost +local:docker` command to open up permissions to display the GUI on your local machine.
 4. You can now proceed to running the tutorials at [https://hnn.brown.edu/index.php/tutorials/](https://hnn.brown.edu/index.php/tutorials/) . Some things to note:
-   * A directory called "hnn_out" exists both inside the container (at /home/hnn_user/hnn_out) and outside (in the directory set by step 2) that can be used to share files between the container and your host OS.
-   * The HNN repository with sample data and parameter files exists at /home/hnn_user/hnn_source_code
+    - A subdirectory called "hnn_out" is created in your home directory and is where simulation results and parameter files will be saved.
 5. To quit HNN and shut down container, first press 'Quit' within the GUI. Then run `./hnn_docker.sh stop`.
 
     ```bash

--- a/installer/windows/docker-compose.yml
+++ b/installer/windows/docker-compose.yml
@@ -10,8 +10,8 @@ services:
     environment:
       XAUTHORITY: "/home/hnn_user/.Xauthority"
       DISPLAY: "host.docker.internal:0"
+      SYSTEM_USER_DIR: $HOME
     volumes:
       - "$XAUTHORITY:/home/hnn_user/.Xauthority"
-      - "./docker_hnn_out:/home/hnn_user/hnn_out"
-      - "../../shared:/home/hnn_user/shared"
+      - "$HOME:$HOME"
     command: "sudo /start_ssh.sh"

--- a/installer/windows/docker-desktop.md
+++ b/installer/windows/docker-desktop.md
@@ -82,8 +82,7 @@ There are two related requirements needed for Docker to be able to run HNN in a 
 4. The HNN GUI should show up. Make sure that you can run simulations by clicking the 'Run Simulation' button. This will run a simulation with the default configuration. After it completes, graphs should be displayed in the main window.
     * If the GUI doesn't show up, check the [Docker troubleshooting section](../docker/troubleshooting.md) (also links the bottom of this page)
 5. You can now proceed to running the tutorials at [https://hnn.brown.edu/index.php/tutorials/](https://hnn.brown.edu/index.php/tutorials/) . Some things to note:
-   * A directory called "hnn_out" exists both inside the container (at /home/hnn_user/hnn_out) and outside (in the directory set by step 2) that can be used to share files between the container and your host OS.
-   * The HNN repository with sample data and parameter files exists at /home/hnn_user/hnn_source_code
+    * A subdirectory called "hnn_out" is created in your home directory and is where simulation results and parameter files will be saved.
 6. To quit HNN and shut down container, first press 'Quit' within the GUI. Then run `./hnn_docker.sh stop`.
 
     ```bash

--- a/installer/windows/docker-toolbox.md
+++ b/installer/windows/docker-toolbox.md
@@ -133,8 +133,7 @@ If you run into problems, check the official Docker Toolbox documentation: [Dock
 3. The HNN GUI should show up. Make sure that you can run simulations by clicking the 'Run Simulation' button. This will run a simulation with the default configuration. After it completes, graphs should be displayed in the main window.
     * If the GUI doesn't show up, check the [Docker troubleshooting section](../docker/troubleshooting.md) (also links the bottom of this page)
 4. You can now proceed to running the tutorials at [https://hnn.brown.edu/index.php/tutorials/](https://hnn.brown.edu/index.php/tutorials/) . Some things to note:
-   * A directory called "hnn_out" exists both inside the container (at /home/hnn_user/hnn_out) and outside (in the directory set by step 2) that can be used to share files between the container and your host OS.
-   * The HNN repository with sample data and parameter files exists at /home/hnn_user/hnn_source_code
+    * A subdirectory called "hnn_out" is created in your home directory and is where simulation results and parameter files will be saved.
 5. To quit HNN and shut down container, first press 'Quit' within the GUI. Then run `./hnn_docker.sh stop`.
 
     ```bash


### PR DESCRIPTION
This updates the default output directory when HNN is run inside a docker container to be hnn_out on the **system OS**, not `/home/hnn_user/hnn_out` inside the container. This is accomplished by sharing the user's home directory with the docker container using the same name as on the system OS.

Thanks @klankinen for the idea. 

Documentation is updated, but this should result in a more intuitive placement of output files.

The docker container is also updated to result in a smaller total image without any large layers (faster parallel pull).