### PR TITLE
[MRG] DOC: give correct VcXsrv version for windows + docker

### DIFF
--- a/installer/mac/native_install.md
+++ b/installer/mac/native_install.md
@@ -12,27 +12,11 @@ This method will run HNN without using virtualization, meaning the GUI may feel 
     curl -s "https://raw.githubusercontent.com/jonescompneurolab/hnn/master/installer/mac/check-pre.sh" | bash
     ```
 
-## Prerequisite 1: XQuartz
-
-1. Download the installer image (version 2.7.11 tested): https://www.xquartz.org/
-2. Open the .dmg image and run XQuartz.pkg within the image, granting privileges when requested.
-3. Start the XQuartz.app by searching for XQuartz in Spotlight (upper right search icon). An "X" icon will appear in the taskbar along with a terminal. We will not use this window because it is difficult to copy and paste into it, so you can close it by clicking on the red x in the upper left corner.
-
-   - Alternatively steps 2 and 3 can be run from the terminal app (enter your user password when prompted after the `sudo` command):
-
-     ```bash
-     hdiutil attach ~/Downloads/XQuartz-2.7.11.dmg
-     sudo installer -pkg /Volumes/XQuartz-2.7.11/XQuartz.pkg -target /
-     hdiutil detach /Volumes/XQuartz-2.7.11
-     rm ~/Downloads/XQuartz-2.7.11.dmg
-     open /Applications/Utilities/XQuartz.app
-     ```
-
 ## Opening a terminal window
 
 1. Open up macOS's terminal.app by searching for terminal in Spotlight (upper right search icon). We will use this terminal for running the commands below.
 
-## Prerequisite 2: Xcode Command Line Tools
+## Prerequisite 1: Xcode Command Line Tools
 
 The Xcode Command Line Tools package includes utilities for compiling code from the terminal (gcc, make, etc.). This is needed for compiling mod files in NEURON.
 
@@ -49,7 +33,7 @@ The Xcode Command Line Tools package includes utilities for compiling code from 
 
   <img src="install_pngs/xcode_tools.png" width="400" />
 
-## Prerequisite 3: NEURON
+## Prerequisite 2: NEURON
 
 1. Download the NEURON macOS installer from [neuron.yale.edu](https://neuron.yale.edu/neuron/download/precompiled-installers). Then run the .pkg installer.
 
@@ -75,7 +59,7 @@ curl -O https://neuron.yale.edu/ftp/neuron/versions/v7.7/nrn-7.7.x86_64-osx.pkg
 sudo installer -pkg /tmp/nrn-7.7.x86_64-osx.pkg -allowUntrusted -target /
 ```
 
-## Prerequisite 4: Miniconda (Python 3)
+## Prerequisite 3: Miniconda (Python 3)
 
 1. Run the commands below from a terminal window (as a regular user). This will create a python environment isolated from other installations on the system. You could use homebrew `brew install python3` if you wish (has been tested with HNN), but this guide will cover the miniconda version.
 

--- a/installer/windows/docker-desktop.md
+++ b/installer/windows/docker-desktop.md
@@ -27,7 +27,7 @@ There are two related requirements needed for Docker to be able to run HNN in a 
 
 ## Prerequisite: VcXsrv
 
-1. Download the installer from [https://sourceforge.net/projects/vcxsrv/files/latest/download](https://sourceforge.net/projects/vcxsrv/files/latest/download) (click [here](https://downloads.sourceforge.net/project/vcxsrv/vcxsrv/1.20.1.4/vcxsrv-64.1.20.1.4.installer.exe?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fvcxsrv%2Ffiles%2Fvcxsrv%2F1.20.1.4%2Fvcxsrv-64.1.20.1.4.installer.exe%2Fdownload%3Fuse_mirror%3Dversaweb%26r%3Dhttps%253A%252F%252Fsourceforge.net%252Fprojects%252Fvcxsrv%252Ffiles%252Flatest%252Fdownload&ts=1550243133) for the direct download link for version 64.1.20.1.4)
+1. Download the installer from [https://sourceforge.net/projects/vcxsrv/files/latest/download](https://sourceforge.net/projects/vcxsrv/files/latest/download)
 2. Run the installer, choosing "C:\Program Files\VcXsrv" as the destination folder. If you choose a different folder the `hnn_docker.sh` script will not be able to launch it automatically.
 
 ## Prerequisite: Docker Desktop
@@ -126,7 +126,33 @@ You can then remove Docker Desktop from "Uninstall a program" in the Control Pan
 
 ## Troubleshooting
 
+### VcXsrv
+
+Make sure VcXsrv has been updated to at least 1.20.60. The instructions used to give a link for 1.20.1.4 which will cause the errors below:
+
+`hnn_docker.sh` would fail:
+
+```bash
+Starting VcXsrv... done
+Checking for xauth... found
+Checking for X11 authentication keys... *failed*
+```
+
+`hnn_docker.log` contains:
+
+```bash
+Retrieving host xauth keys...
+
+  ** Command: /c/Program Files/VcXsrv/xauth.exe -f /c/Users/user/.Xauthority -ni nlist localhost:0
+  ** Stderr: C:\Program Files\VcXsrv\xauth.exe: (argv):1:  bad display name "localhost:0" in "nlist" command
+*failed*
+```
+
+### Docker
+
 For errors related to Docker, please see the [Docker troubleshooting section](../docker/troubleshooting.md)
+
+### Other
 
 If you run into other issues with the installation, please [open an issue on our GitHub](https://github.com/jonescompneurolab/hnn/issues). Our team monitors these issues and will be able to suggest possible fixes.
 

--- a/installer/windows/docker-toolbox.md
+++ b/installer/windows/docker-toolbox.md
@@ -24,7 +24,6 @@ It is necessary to turn off Hyper-V for using HNN with Docker Toolbox. You may f
 ## Prerequisite: VcXsrv (XLaunch)
 
 1. Download the installer from [https://sourceforge.net/projects/vcxsrv/files/latest/download](https://sourceforge.net/projects/vcxsrv/files/latest/download)
-   * Here's the link to the [direct download of version 64.1.20.1.4](https://downloads.sourceforge.net/project/vcxsrv/vcxsrv/1.20.1.4/vcxsrv-64.1.20.1.4.installer.exe?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fvcxsrv%2Ffiles%2Fvcxsrv%2F1.20.1.4%2Fvcxsrv-64.1.20.1.4.installer.exe%2Fdownload%3Fuse_mirror%3Dversaweb%26r%3Dhttps%253A%252F%252Fsourceforge.net%252Fprojects%252Fvcxsrv%252Ffiles%252Flatest%252Fdownload&ts=1550243133)
 2. Run the installer, choosing "C:\Program Files\VcXsrv" as the destination folder. If you choose a different folder the `hnn_docker.sh` script will not be able to launch it automatically.
 
 ## Prerequisite: Docker Toolbox
@@ -187,7 +186,33 @@ If you'd like to be able to copy files from the host OS without using the shared
 
 ## Troubleshooting
 
+### VcXsrv
+
+Make sure VcXsrv has been updated to at least 1.20.6.0. The instructions used to give a link for 1.20.1.4 which will cause the errors below:
+
+`hnn_docker.sh` would fail:
+
+```bash
+Starting VcXsrv... done
+Checking for xauth... found
+Checking for X11 authentication keys... *failed*
+```
+
+`hnn_docker.log` contains:
+
+```bash
+Retrieving host xauth keys...
+
+  ** Command: /c/Program Files/VcXsrv/xauth.exe -f /c/Users/user/.Xauthority -ni nlist localhost:0
+  ** Stderr: C:\Program Files\VcXsrv\xauth.exe: (argv):1:  bad display name "localhost:0" in "nlist" command
+*failed*
+```
+
+### Docker
+
 For errors related to Docker, please see the [Docker troubleshooting section](../docker/troubleshooting.md)
+
+### Other
 
 If you run into other issues with the installation, please [open an issue on our GitHub](https://github.com/jonescompneurolab/hnn/issues). Our team monitors these issues and will be able to suggest possible fixes.
 

--- a/scripts/docker_functions.sh
+++ b/scripts/docker_functions.sh
@@ -2077,7 +2077,7 @@ function set_local_display_from_port {
   # no arguments
   # set DISPLAY for local actions (e.g. generating xauth keys)
   if [[ "$OS" =~ "windows" ]]; then
-    DISPLAY="127.0.0.1:$__port"
+    DISPLAY="localhost:$__port"
   elif [[ "$OS" =~ "mac" ]]; then
     DISPLAY=":$__port"
   else


### PR DESCRIPTION
The old link to 1.20.1.4 directed users to install a version of VcXsrv that didn't work with `hnn_docker.sh`! This corrects the instructions and adds a troubleshooting section on the bug. Also reverts a previous commit to use `127.0.0.1:0` instead of `localhost:0` for the display name in an attempt to fix this problem.