### PR TITLE
[WIP] TST: add view window tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -171,3 +171,6 @@ script:
       wsl -- bash -e //home/hnn_user/hnn/scripts/run-travis-wsl.sh
       stop_vcxsrv || script_fail
     fi
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ before_install:
       echo "Installing macOS prerequisites"
 
       scripts/setup-travis-mac.sh
-      export PATH=${HOME}/miniconda/bin:$PATH
+      export PATH=${HOME}/Miniconda3/bin:$PATH
       export PATH=$PATH:/Applications/NEURON-${NEURON_VERSION}/nrn/x86_64/bin
       export PYTHONPATH=/Applications/NEURON-${NEURON_VERSION}/nrn/lib/python:$PYTHONPATH
       export PYTHON=python3

--- a/.travis.yml
+++ b/.travis.yml
@@ -163,7 +163,7 @@ script:
     $PYTHON hnn.py
   - | # Run py.test that includes running a simulation and verifying results
     echo "Running Python tests on host OS..."
-    py.test tests/
+    py.test --cov=. tests/
   - | # Test WSL-based version on windows (needs VcXsrv)
     if [[ "${TRAVIS_OS_NAME}" == "windows" ]]; then
       find_command_suggested_path "vcxsrv" "/c/Program Files/VcXsrv" && \

--- a/scripts/setup-travis-mac.sh
+++ b/scripts/setup-travis-mac.sh
@@ -11,13 +11,12 @@ start_download "$FILENAME" "$URL"
 
 echo "Installing miniconda..."
 chmod +x "$HOME/miniconda.sh"
-"$HOME/miniconda.sh" -b -p "${HOME}/miniconda"
-export PATH=${HOME}/miniconda/bin:$PATH
+"$HOME/miniconda.sh" -b -p "${HOME}/Miniconda3"
+export PATH=${HOME}/Miniconda3/bin:$PATH
 
 # create conda environment
 conda create -n hnn --yes python=${PYTHON_VERSION} pip openmpi scipy numpy matplotlib pyqtgraph pyopengl psutil
 source activate hnn && echo "activated conda HNN environment"
-# export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/miniconda/envs/hnn/lib
 
 # conda is faster to install nlopt
 conda install -y -n hnn -c conda-forge nlopt

--- a/spikefn.py
+++ b/spikefn.py
@@ -153,14 +153,7 @@ class ExtInputs (Spikes):
 
   def __get_extinput_times (self, fspk):
     # load all spike times from file
-    s_all = []
-    try:
-      s_all = np.loadtxt(open(fspk, 'rb'))
-    except OSError:
-      print('Warning: could not read file:', fspk)
-    except ValueError:
-      print('Warning: error reading data from:', fspk)
-
+    s_all = np.loadtxt(open(fspk, 'rb'))
     if len(s_all) == 0:
       # couldn't read spike times
       raise ValueError

--- a/tests/test_compare_hnn.py
+++ b/tests/test_compare_hnn.py
@@ -20,14 +20,15 @@ def test_hnn():
     paramf = op.join('param', 'default.param')
 
     nrniv_str = 'nrniv -python -nobanner'
-    cmd = nrniv_str + ' ' + sys.executable + ' run.py ' + paramf + ' ntrial ' + str(ntrials)
+    cmd = nrniv_str + ' ' + sys.executable + ' run.py ' + paramf \
+        + ' ntrial ' + str(ntrials)
 
     # Split the command into shell arguments for passing to Popen
     cmdargs = shlex.split(cmd, posix="win" not in sys.platform)
 
     # Start the simulation
     proc = Popen(cmdargs, stdin=PIPE, stdout=PIPE, stderr=PIPE,
-                    cwd=os.getcwd(), universal_newlines=True)
+                 cwd=os.getcwd(), universal_newlines=True)
     out, err = proc.communicate()
 
     # print all messages (including error messages)
@@ -44,7 +45,7 @@ def test_hnn():
 
         data_dir = ('https://raw.githubusercontent.com/jonescompneurolab/'
                     'hnn/test_data/')
-        for data_type in [ 'dpl', 'rawdpl', 'i']:
+        for data_type in ['dpl', 'rawdpl', 'i']:
             sys.stdout.write("%s..." % data_type)
 
             fname = "%s_%d.txt" % (data_type, trial)

--- a/tests/test_view_windows.py
+++ b/tests/test_view_windows.py
@@ -16,8 +16,14 @@ def fetch_file(fname):
         _fetch_file(data_url, fname)
 
 
-def view_window(cmd):
+def view_window(code_fname, paramf, data_fname=None):
     """Test to check that viewer displays without error"""
+
+    nrniv_str = 'nrniv -python -nobanner'
+    cmd = nrniv_str + ' ' + sys.executable + ' ' + code_fname + ' ' + \
+          paramf
+    if not data_fname is None:
+        cmd += ' ' + data_fname
 
     # Split the command into shell arguments for passing to Popen
     cmdargs = shlex.split(cmd, posix="win" not in sys.platform)
@@ -34,50 +40,25 @@ def view_window(cmd):
     if proc.returncode != 0:
         raise RuntimeError("Running command %s failed" % cmd)
 
-
 def test_view_rast():
-    if 'SYSTEM_USER_DIR' in os.environ:
-        basedir = os.environ['SYSTEM_USER_DIR']
-    else:
-        basedir = os.path.expanduser('~')
-
-    fetch_file('spk.txt')
-    ntrials = 3
-    for trial_idx in range(ntrials):
-        fetch_file('spk_%d.txt' % trial_idx)
-
-    spike_file = os.path.join(basedir, 'spk.txt')
+    fname = 'spk.txt'
+    fetch_file(fname)
     paramf = op.join('param', 'default.param')
-    cmd = sys.executable + ' visrast.py ' + paramf + ' ' + spike_file
-
-    view_window(cmd)
+    view_window('visrast.py', paramf, fname)
 
 
 def test_view_dipole():
-    if 'SYSTEM_USER_DIR' in os.environ:
-        basedir = os.environ['SYSTEM_USER_DIR']
-    else:
-        basedir = os.path.expanduser('~')
-
-    fetch_file('dpl.txt')
-    ntrials = 3
-    for trial_idx in range(ntrials):
-        fetch_file('dpl_%d.txt' % trial_idx)
-
-    dipole_file = os.path.join(basedir, 'dpl.txt')
+    fname = 'dpl.txt'
+    fetch_file(fname)
     paramf = op.join('param', 'default.param')
-    cmd = sys.executable + ' visdipole.py ' + paramf + ' ' + dipole_file
-
-    view_window(cmd)
+    view_window('visdipole.py', paramf, fname)
 
 
 def test_view_psd():
     paramf = op.join('param', 'default.param')
-    cmd = sys.executable + ' vispsd.py ' + paramf
-    view_window(cmd)
+    view_window('vispsd.py', paramf)
 
 
 def test_view_spec():
     paramf = op.join('param', 'default.param')
-    cmd = sys.executable + ' visspec.py ' + paramf
-    view_window(cmd)
+    view_window('visspec.py', paramf)

--- a/tests/test_view_windows.py
+++ b/tests/test_view_windows.py
@@ -1,0 +1,33 @@
+import os.path as op
+import os
+import sys
+import shlex
+from subprocess import Popen, PIPE
+
+from numpy import loadtxt
+from numpy.testing import assert_allclose
+
+
+def test_view_dipole():
+    """Test to check that Dipole viewer displays without error"""
+
+    if 'SYSTEM_USER_DIR' in os.environ:
+        basedir = os.environ['SYSTEM_USER_DIR']
+    else:
+        basedir = os.path.expanduser('~')
+
+    dipole_file = os.path.join(basedir, 'dpl.txt')
+    paramf = op.join('param', 'default.param')
+    cmd = sys.executable + ' visdipole.py ' + paramf + ' ' + dipole_file
+
+    # Split the command into shell arguments for passing to Popen
+    cmdargs = shlex.split(cmd, posix="win" not in sys.platform)
+
+    # Start the simulation
+    proc = Popen(cmdargs, stdin=PIPE, stdout=PIPE, stderr=PIPE,
+                    cwd=os.getcwd(), universal_newlines=True)
+    out, err = proc.communicate()
+
+    # print all messages (including error messages)
+    print('STDOUT', out)
+    print('STDERR', err)

--- a/tests/test_view_windows.py
+++ b/tests/test_view_windows.py
@@ -21,14 +21,16 @@ def view_window(code_fname, paramf, data_fname=None):
 
     nrniv_str = 'nrniv -python -nobanner'
     cmd = nrniv_str + ' ' + sys.executable + ' ' + code_fname + ' ' + \
-          paramf
-    if not data_fname is None:
+        paramf
+    if data_fname is not None:
         cmd += ' ' + data_fname
 
-    # Windows will fail to load the correct Qt plugin when launched with nrniv. This is a temporary
-    # fix until separate windows are no longer launched as different processes.
+    # Windows will fail to load the correct Qt plugin when launched with nrniv
+    # This is a temporary fix until separate windows are no longer launched
+    # as different processes
     basedir = os.path.expanduser('~')
-    plugin_dir = op.join(basedir, 'Miniconda3', 'envs', 'hnn', 'Library', 'plugins', 'platforms')
+    plugin_dir = op.join(basedir, 'Miniconda3', 'envs', 'hnn', 'Library',
+                         'plugins', 'platforms')
     os.environ['QT_QPA_PLATFORM_PLUGIN_PATH'] = plugin_dir
 
     # Split the command into shell arguments for passing to Popen
@@ -45,6 +47,7 @@ def view_window(code_fname, paramf, data_fname=None):
 
     if proc.returncode != 0:
         raise RuntimeError("Running command %s failed" % cmd)
+
 
 def test_view_rast():
     fname = 'spk.txt'

--- a/tests/test_view_windows.py
+++ b/tests/test_view_windows.py
@@ -8,17 +8,8 @@ from numpy import loadtxt
 from numpy.testing import assert_allclose
 
 
-def test_view_dipole():
-    """Test to check that Dipole viewer displays without error"""
-
-    if 'SYSTEM_USER_DIR' in os.environ:
-        basedir = os.environ['SYSTEM_USER_DIR']
-    else:
-        basedir = os.path.expanduser('~')
-
-    dipole_file = os.path.join(basedir, 'dpl.txt')
-    paramf = op.join('param', 'default.param')
-    cmd = sys.executable + ' visdipole.py ' + paramf + ' ' + dipole_file
+def view_window(cmd):
+    """Test to check that viewer displays without error"""
 
     # Split the command into shell arguments for passing to Popen
     cmdargs = shlex.split(cmd, posix="win" not in sys.platform)
@@ -31,3 +22,37 @@ def test_view_dipole():
     # print all messages (including error messages)
     print('STDOUT', out)
     print('STDERR', err)
+
+def test_view_rast():
+    if 'SYSTEM_USER_DIR' in os.environ:
+        basedir = os.environ['SYSTEM_USER_DIR']
+    else:
+        basedir = os.path.expanduser('~')
+
+    spike_file = os.path.join(basedir, 'spk.txt')
+    paramf = op.join('param', 'default.param')
+    cmd = sys.executable + ' visrast.py ' + paramf + ' ' + spike_file
+
+    view_window(cmd)
+
+def test_view_dipole():
+    if 'SYSTEM_USER_DIR' in os.environ:
+        basedir = os.environ['SYSTEM_USER_DIR']
+    else:
+        basedir = os.path.expanduser('~')
+
+    dipole_file = os.path.join(basedir, 'dpl.txt')
+    paramf = op.join('param', 'default.param')
+    cmd = sys.executable + ' visrast.py ' + paramf + ' ' + dipole_file
+
+    view_window(cmd)
+
+def test_view_psd():
+    paramf = op.join('param', 'default.param')
+    cmd = sys.executable + ' vispsd.py ' + paramf
+    view_window(cmd)
+
+def test_view_spec():
+    paramf = op.join('param', 'default.param')
+    cmd = sys.executable + ' visspec.py ' + paramf
+    view_window(cmd)

--- a/tests/test_view_windows.py
+++ b/tests/test_view_windows.py
@@ -25,6 +25,12 @@ def view_window(code_fname, paramf, data_fname=None):
     if not data_fname is None:
         cmd += ' ' + data_fname
 
+    # Windows will fail to load the correct Qt plugin when launched with nrniv. This is a temporary
+    # fix until separate windows are no longer launched as different processes.
+    basedir = os.path.expanduser('~')
+    plugin_dir = op.join(basedir, 'Miniconda3', 'envs', 'hnn', 'Library', 'plugins', 'platforms')
+    os.environ['QT_QPA_PLATFORM_PLUGIN_PATH'] = plugin_dir
+
     # Split the command into shell arguments for passing to Popen
     cmdargs = shlex.split(cmd, posix="win" not in sys.platform)
 

--- a/tests/test_view_windows.py
+++ b/tests/test_view_windows.py
@@ -4,8 +4,16 @@ import sys
 import shlex
 from subprocess import Popen, PIPE
 
-from numpy import loadtxt
-from numpy.testing import assert_allclose
+from mne.utils import _fetch_file
+
+
+def fetch_file(fname):
+    data_dir = ('https://raw.githubusercontent.com/jonescompneurolab/'
+                'hnn/test_data/')
+
+    data_url = op.join(data_dir, fname)
+    if not op.exists(fname):
+        _fetch_file(data_url, fname)
 
 
 def view_window(cmd):
@@ -16,12 +24,16 @@ def view_window(cmd):
 
     # Start the simulation
     proc = Popen(cmdargs, stdin=PIPE, stdout=PIPE, stderr=PIPE,
-                    cwd=os.getcwd(), universal_newlines=True)
+                 cwd=os.getcwd(), universal_newlines=True)
     out, err = proc.communicate()
 
     # print all messages (including error messages)
     print('STDOUT', out)
     print('STDERR', err)
+
+    if proc.returncode != 0:
+        raise RuntimeError("Running command %s failed" % cmd)
+
 
 def test_view_rast():
     if 'SYSTEM_USER_DIR' in os.environ:
@@ -29,11 +41,17 @@ def test_view_rast():
     else:
         basedir = os.path.expanduser('~')
 
+    fetch_file('spk.txt')
+    ntrials = 3
+    for trial_idx in range(ntrials):
+        fetch_file('spk_%d.txt' % trial_idx)
+
     spike_file = os.path.join(basedir, 'spk.txt')
     paramf = op.join('param', 'default.param')
     cmd = sys.executable + ' visrast.py ' + paramf + ' ' + spike_file
 
     view_window(cmd)
+
 
 def test_view_dipole():
     if 'SYSTEM_USER_DIR' in os.environ:
@@ -41,16 +59,23 @@ def test_view_dipole():
     else:
         basedir = os.path.expanduser('~')
 
+    fetch_file('dpl.txt')
+    ntrials = 3
+    for trial_idx in range(ntrials):
+        fetch_file('dpl_%d.txt' % trial_idx)
+
     dipole_file = os.path.join(basedir, 'dpl.txt')
     paramf = op.join('param', 'default.param')
-    cmd = sys.executable + ' visrast.py ' + paramf + ' ' + dipole_file
+    cmd = sys.executable + ' visdipole.py ' + paramf + ' ' + dipole_file
 
     view_window(cmd)
+
 
 def test_view_psd():
     paramf = op.join('param', 'default.param')
     cmd = sys.executable + ' vispsd.py ' + paramf
     view_window(cmd)
+
 
 def test_view_spec():
     paramf = op.join('param', 'default.param')

--- a/visdipole.py
+++ b/visdipole.py
@@ -131,7 +131,7 @@ class DipoleCanvas (FigureCanvas):
     self.draw()
 
   if "TRAVIS_TESTING" in os.environ and os.environ["TRAVIS_TESTING"] == "1":
-    print("Exciting gracefully with TRAVIS_TESTING=1")
+    print("Exiting gracefully with TRAVIS_TESTING=1")
     qApp.quit()
     exit(0)
 

--- a/visdipole.py
+++ b/visdipole.py
@@ -130,6 +130,11 @@ class DipoleCanvas (FigureCanvas):
     self.drawdipole(self.figure)
     self.draw()
 
+  if "TRAVIS_TESTING" in os.environ and os.environ["TRAVIS_TESTING"] == "1":
+    print("Exciting gracefully with TRAVIS_TESTING=1")
+    qApp.quit()
+    exit(0)
+
 if __name__ == '__main__':
   app = QApplication(sys.argv)
   ex = DataViewGUI(DipoleCanvas,paramf,ntrial,'Dipole Viewer')

--- a/vispsd.py
+++ b/vispsd.py
@@ -193,6 +193,11 @@ class PSDViewGUI (DataViewGUI):
     self.lextpsd = [] # external data psd
     self.lextfiles = [] # external data files
 
+    if "TRAVIS_TESTING" in os.environ and os.environ["TRAVIS_TESTING"] == "1":
+      print("Exiting gracefully with TRAVIS_TESTING=1")
+      qApp.quit()
+      exit(0)
+
   def addLoadDataActions (self):
     loadDataFile = QAction(QIcon.fromTheme('open'), 'Load data file.', self)
     loadDataFile.setShortcut('Ctrl+D')

--- a/visrast.py
+++ b/visrast.py
@@ -49,11 +49,7 @@ for i in range(len(sys.argv)):
     PoissonInputs = paramrw.usingPoissonInputs(paramf)
     outparamf = os.path.join(dconf['datdir'],paramf.split('.param')[0].split(os.path.sep)[-1],'param.txt')
 
-try:
-  extinputs = spikefn.ExtInputs(spkpath, outparamf)
-except ValueError:
-  print("Error: could not load spike timings from %s" % spkpath)
-
+extinputs = spikefn.ExtInputs(spkpath, outparamf)
 extinputs.add_delay_times()
 
 alldat = {}

--- a/visrast.py
+++ b/visrast.py
@@ -275,6 +275,11 @@ class SpikeGUI (QMainWindow):
     super().__init__()        
     self.initUI()
 
+    if "TRAVIS_TESTING" in os.environ and os.environ["TRAVIS_TESTING"] == "1":
+      print("Exiting gracefully with TRAVIS_TESTING=1")
+      qApp.quit()
+      exit(0)
+
   def initMenu (self):
     exitAction = QAction(QIcon.fromTheme('exit'), 'Exit', self)        
     exitAction.setShortcut('Ctrl+Q')

--- a/visspec.py
+++ b/visspec.py
@@ -213,6 +213,11 @@ class SpecViewGUI (DataViewGUI):
     if len(paramf):
       self.loadDisplayData(paramf)
 
+    if "TRAVIS_TESTING" in os.environ and os.environ["TRAVIS_TESTING"] == "1":
+      print("Exiting gracefully with TRAVIS_TESTING=1")
+      qApp.quit()
+      exit(0)
+
   def initCanvas (self):
     super(SpecViewGUI,self).initCanvas()
     self.m.lextspec = self.lextspec


### PR DESCRIPTION
Just like we initialize the main HNN GUI window (hnn_qt5.py) during testing and then have it gracefully exit with `TRAVIS_TESTING=1`, we can do the same with windows showing dipole, raster, spectrogram, and PSD plots. This PR adds tests for each of those windows that simply initializes the window and then exits. If there no uncaught exceptions, then the process that started the window will exit successfully and the test will pass.

Tests can be improved further in #232 (a test for somatic voltages should be added). Having this in place will allow for catching errors potentially exposed by #236. 

Resolves #243