### PR TITLE
Added ubuntu 20.04 to installation script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,17 @@ matrix:
           packages:
             - xvfb
 
+      - os: linux
+        dist: focal
+        name: "Ubuntu focal"
+        env:
+          - NEURON_VERSION=7.7
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - xvfb
+
 before_install:
   - set -e  # error on any command failure
   - | # function exports

--- a/installer/ubuntu/hnn-ubuntu.sh
+++ b/installer/ubuntu/hnn-ubuntu.sh
@@ -48,6 +48,8 @@ echo "Output in log file: $LOGFILE"
     PYTHON_VERSION=3.6
   elif [[ "$DISTRIB" =~ "disco" ]]; then
     PYTHON_VERSION=3.7
+  elif [[ "$DISTRIB" =~ "focal" ]]; then
+    PYTHON_VERSION=3.8
   else
     echo "Error: Ubuntu distribtion $DISTRIB not supported" | tee -a "$LOGFILE"
     exit 1


### PR DESCRIPTION
The installation script seems to work fine for Ubuntu 20.04 (Focal Fossa) (only tested for a single machine, though, which was not a fresh installation). The only necessary change is a new arm in the switch statement that sets the corresponding python version.