### PR TITLE
MRG: get number of hist bins using ceil, not int

### DIFF
--- a/hnn/qt_spike.py
+++ b/hnn/qt_spike.py
@@ -90,7 +90,7 @@ def getdspk(spikes, extinputs, tstop):
             haveinputs = True
     for ty in dhist.keys():
         dhist[ty] = np.histogram(dhist[ty], range=(0, tstop),
-                                 bins=int(tstop / binsz))
+                                 bins=ceil(tstop / binsz))
         if smoothsz > 0:
             dhist[ty] = hammfilt(dhist[ty][0], smoothsz)
         else:


### PR DESCRIPTION
When tstop is not divisible by 5.0 (global, yuck!), the histogram
that gets created is too small for the x-axis of the plots. Use
ceil() to round up.

Fixes #177