### PR TITLE
Add codespell: config, workflow and get it to fix some typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,5 @@
+[codespell]
+skip = .git,*.pdf,*.svg,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.codespellrc
+++ b/.codespellrc
@@ -2,4 +2,4 @@
 skip = .git,*.pdf,*.svg,.codespellrc
 check-hidden = true
 # ignore-regex = 
-# ignore-words-list =
+ignore-words-list = nam,fam,usera

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,22 @@
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/hnn/qt_evoked.py
+++ b/hnn/qt_evoked.py
@@ -831,7 +831,7 @@ class OptEvokedInputParamDialog (EvokedInputBaseDialog):
                     self.dqchkbox[k].setChecked(False)
                 else:
                     self.dqchkbox[k].setChecked(True)
-                # use partial instead of lamda (so args won't be evaluated
+                # use partial instead of lambda (so args won't be evaluated
                 # ahead of time?)
                 self.dqchkbox[k].clicked.connect(
                     partial(self.toggle_enable_param, k))
@@ -1155,7 +1155,7 @@ class OptEvokedInputParamDialog (EvokedInputBaseDialog):
         self.old_num_steps = 0
 
     def rebuildOptStepInfo(self):
-        # split chunks from paramter file
+        # split chunks from parameter file
         self.chunk_list = _chunk_evinputs(
             self.opt_params, self.simlength, self.sim_dt)
 

--- a/installer/docker/start_hnn.sh
+++ b/installer/docker/start_hnn.sh
@@ -20,7 +20,7 @@ cd "$HOME/hnn_source_code"
 QT_CONF="$HOME/.config/QtProject.conf"
 if [[ -f "$QT_CONF" ]]; then
   if [[ ! -w "$QT_CONF" ]]; then
-    echo "Incorrect permissions to modifiy $QT_CONF"
+    echo "Incorrect permissions to modify $QT_CONF"
   else
     echo -n "Updating Qt preferences... "
     grep -q "SYSTEM_USER_DIR" "$QT_CONF" > /dev/null 2>&1

--- a/installer/mac/README.md
+++ b/installer/mac/README.md
@@ -67,7 +67,7 @@ The Xcode Command Line Tools package includes utilities for compiling code from 
     pip install nlopt NEURON
     ```
 
-3. Set the LD_LIBRARY_PATH for openmpi on conda activation. This environnement variable must be set before HNN can run simulations with openmpi. The variable is only useful inside the 'hnn' conda environment, so we will set the variable when conda is activated with `source activate hnn`. Run the following commands to make this automatic.
+3. Set the LD_LIBRARY_PATH for openmpi on conda activation. This environment variable must be set before HNN can run simulations with openmpi. The variable is only useful inside the 'hnn' conda environment, so we will set the variable when conda is activated with `source activate hnn`. Run the following commands to make this automatic.
 
     ```bash
     cd ${CONDA_PREFIX}

--- a/installer/mac/check-post.sh
+++ b/installer/mac/check-post.sh
@@ -182,7 +182,7 @@ fi
 # NEURON functionality checks from https://github.com/jonescompneurolab/hnn/issues/11
 NRNIV_WORKS=
 if [[ "$NRN_FOUND" -eq "1" ]]; then
-  echo -n "Checking NEURON nrniv funtionality..."
+  echo -n "Checking NEURON nrniv functionality..."
   COMMAND="nrniv -nobanner -nopython -c '{print \"hello\" quit()}' 2>&1"
   OUTPUT=$(nrniv -nobanner -nopython -c '{print "hello" quit()}' 2>&1)
   if [[ "$?" -eq "0" ]]; then
@@ -198,7 +198,7 @@ if [[ "$NRN_FOUND" -eq "1" ]]; then
     return=2
   fi
 else
-  echo "Skipping NEURON funtionality tests."
+  echo "Skipping NEURON functionality tests."
 fi
 
 PREREQS_INSTALLED=1
@@ -218,7 +218,7 @@ done
 
 NRNIV_AND_PYTHON_WORKS=
 if [[ "$NRN_FOUND" -eq "1" ]] && [[ "$NRNIV_WORKS" -eq "1" ]] && [[ "$PREREQS_INSTALLED" -eq "1" ]]; then
-  echo -n "Checking NEURON nrniv funtionality with Python..."
+  echo -n "Checking NEURON nrniv functionality with Python..."
   COMMAND="nrniv -nobanner -python -c 'from neuron import h; print(\"Hello\"); h.quit()' 2>&1"
   OUTPUT=$(nrniv -nobanner -python -c 'from neuron import h; print("Hello"); h.quit()' 2>&1)
   if [[ "$?" -eq "0" ]]; then
@@ -234,7 +234,7 @@ if [[ "$NRN_FOUND" -eq "1" ]] && [[ "$NRNIV_WORKS" -eq "1" ]] && [[ "$PREREQS_IN
     return=2
     fi
 else
-  echo "Skipping NEURON funtionality tests with Python."
+  echo "Skipping NEURON functionality tests with Python."
 fi
 
 echo -n "Checking for setting LD_LIBRARY_PATH..."
@@ -251,7 +251,7 @@ fi
 
 MPI_AND_NRNIV_WORKS=
 if [[ "$NRN_FOUND" -eq "1" ]] && [[ "$NRNIV_WORKS" -eq "1" ]] && [[ "$MPI_WORKS" -eq "1" ]]; then
-  echo -n "Checking NEURON nrniv funtionality with MPI..."
+  echo -n "Checking NEURON nrniv functionality with MPI..."
   mpiexec -n 2 nrniv -nobanner -nopython -mpi -c 'quit()' > /dev/null 2>&1
   if [[ "$?" -eq "0" ]]; then
     echo "ok"
@@ -280,14 +280,14 @@ if [[ "$NRN_FOUND" -eq "1" ]] && [[ "$NRNIV_WORKS" -eq "1" ]] && [[ "$MPI_WORKS"
     fi
   fi
 else
-  echo "Skipping NEURON funtionality tests with MPI."
+  echo "Skipping NEURON functionality tests with MPI."
 fi
 
 NRNIV_AND_PYTHON_AND_MPI_WORKS=
 if [[ "$NRN_FOUND" -eq "1" ]] && [[ "$NRNIV_WORKS" -eq "1" ]] &&
   [[ "$PREREQS_INSTALLED" -eq "1" ]] && [[ "$MPI_WORKS" -eq "1" ]] &&
   [[ "$MPI_AND_NRNIV_WORKS" -eq "1" ]]; then
- echo -n "Checking NEURON nrniv funtionality with Python and MPI..."
+ echo -n "Checking NEURON nrniv functionality with Python and MPI..."
  COMMAND="mpiexec -n 2 nrniv -nobanner -mpi -python -c 'from neuron import h; pc = h.ParallelContext(); h.quit()'  2>&1"
  OUTPUT=$(mpiexec -n 2 nrniv -nobanner -mpi -python -c 'from neuron import h; pc = h.ParallelContext(); h.quit()'  2>&1)
  if [[ "$?" -eq "0" ]]; then
@@ -302,7 +302,7 @@ if [[ "$NRN_FOUND" -eq "1" ]] && [[ "$NRNIV_WORKS" -eq "1" ]] &&
    return=2
    fi
 else
- echo "Skipping NEURON funtionality tests with Python and MPI."
+ echo "Skipping NEURON functionality tests with Python and MPI."
 fi
 
 

--- a/installer/ubuntu/hnn-ubuntu.sh
+++ b/installer/ubuntu/hnn-ubuntu.sh
@@ -38,7 +38,7 @@ function script_fail {
 trap script_fail EXIT
 
 DISTRIB=$(grep DISTRIB_CODENAME /etc/lsb-release | cut -d'=' -f2)
-echo "Starting installation of HNN on dectected Ubuntu OS: $DISTRIB" | tee -a "$LOGFILE"
+echo "Starting installation of HNN on detected Ubuntu OS: $DISTRIB" | tee -a "$LOGFILE"
 echo "Output in log file: $LOGFILE"
 
 [[ $PYTHON_VERSION ]] || {
@@ -51,7 +51,7 @@ echo "Output in log file: $LOGFILE"
   elif [[ "$DISTRIB" =~ "focal" ]]; then
     PYTHON_VERSION=3.8
   else
-    echo "Error: Ubuntu distribtion $DISTRIB not supported" | tee -a "$LOGFILE"
+    echo "Error: Ubuntu distribution $DISTRIB not supported" | tee -a "$LOGFILE"
     exit 1
   fi
 }

--- a/installer/windows/docker-desktop.md
+++ b/installer/windows/docker-desktop.md
@@ -8,7 +8,7 @@ There are two related requirements needed for Docker to be able to run HNN in a 
 
 1. Hardware virtualization features (manual setting)
 
-    If not already enabled, it may be necessary to manually set these through your PC manufacturer's BIOS settings. Only old systems do not support this feature. However, if Docker cannot turn this feature on from its installer, you may need to reboot your computer and change your PC manufacturer's BIOS settings. You can check whether it is enabled from the Task Manger. The picture below shows that hardware virtualization is disabled and will need to be manually enabled in the BIOS.
+    If not already enabled, it may be necessary to manually set these through your PC manufacturer's BIOS settings. Only old systems do not support this feature. However, if Docker cannot turn this feature on from its installer, you may need to reboot your computer and change your PC manufacturer's BIOS settings. You can check whether it is enabled from the Task Manager. The picture below shows that hardware virtualization is disabled and will need to be manually enabled in the BIOS.
 
     <img src="install_pngs/virtualization_disabled.png" width="600" />
 
@@ -125,7 +125,7 @@ There are two related requirements needed for Docker to be able to run HNN in a 
    - The HNN repository with sample data and parameter files exists at /home/hnn_user/hnn_source_code
    - If you run into problems starting the Docker container or the GUI is not displaying, please see the [Docker troubleshooting section](../docker/README.md#Troubleshooting)
 
-## Updgrading to a new version of HNN
+## Upgrading to a new version of HNN
 
 1. Verify that VcXsrv and Docker are running. VcXsrv will not start automatically after a reboot by default.
 2. Open a Command Prompt (cmd.exe)

--- a/installer/windows/docker-toolbox.md
+++ b/installer/windows/docker-toolbox.md
@@ -4,7 +4,7 @@
 
 ## Prerequisite: hardware virtualization features
 
-Nearly all PC's have this feature, but it may not be enabled by default. If not already enabled, it may be necessary to manually set these through your PC manufacturer's BIOS settings. However, if Docker cannot turn this feature on from its installer, you may need to reboot your computer and change your PC manufacturer's BIOS settings. You can check whether it is enabled from the Task Manger. The picture below shows that hardware virtualization is disabled and will need to be manually enabled in the BIOS.
+Nearly all PC's have this feature, but it may not be enabled by default. If not already enabled, it may be necessary to manually set these through your PC manufacturer's BIOS settings. However, if Docker cannot turn this feature on from its installer, you may need to reboot your computer and change your PC manufacturer's BIOS settings. You can check whether it is enabled from the Task Manager. The picture below shows that hardware virtualization is disabled and will need to be manually enabled in the BIOS.
 
   <img src="install_pngs/virtualization_disabled.png" width="600" />
 

--- a/scripts/docker_functions.sh
+++ b/scripts/docker_functions.sh
@@ -366,7 +366,7 @@ function output_run_command_arguments {
   if [[ -n "$__output" ]]; then
     echo >> "$LOGFILE"
     if [[ $SUPPRESS_OUTPUT -eq 1 ]]; then
-      echo "  ** Stdout: ** suppresed **" >> "$LOGFILE"
+      echo "  ** Stdout: ** suppressed **" >> "$LOGFILE"
       SUPPRESS_OUTPUT=1
     else
       echo "  ** Stdout: $__output" | tr -d '\r' >> "$LOGFILE"
@@ -644,7 +644,7 @@ function get_container_port {
 function ssh_start_hnn_print {
   # no args
   # Will try to ssh into container to start HNN. Designed to be called
-  # multiple times beause the function could fail due to trouble
+  # multiple times because the function could fail due to trouble
   # getting the container port or the ssh command fails (bad keys maybe).
   check_var DOCKER_TOOLBOX
   check_var SSH_PRIVKEY
@@ -1674,7 +1674,7 @@ function docker_run_fail {
     cleanup 2
   fi
 
-  # make sure "docker ps | grep HNN_CONTAINER_NAME" succeeeds
+  # make sure "docker ps | grep HNN_CONTAINER_NAME" succeeds
   __started=$(wait_for_container_to_start $__timeout)
   if [[ ! "$__started" =~ "1" ]]; then
     echo "*failed*" | tee -a "$LOGFILE"
@@ -1773,7 +1773,7 @@ function check_xauth_keys_print {
 }
 
 function start_check_container_sshd_fail {
-  # no arguemnts
+  # no arguments
   # run /start_ssh.sh within container and detach, leaving sshd running
   check_var docker_cmd
   check_var HNN_CONTAINER_NAME
@@ -1922,7 +1922,7 @@ function get_valid_host_xauth_key {
 
 function get_container_xauth_key {
   # first argument is username inside container to check permissions for
-  # checks that xauth run within container retuns valid keys
+  # checks that xauth run within container returns valid keys
 
   check_args "$@" $# 1
 


### PR DESCRIPTION
codespell workflow would just detect when typos introduced, not fix them automagically. Run `codespell -w` locally to do that. Can use pre-commit to automate. See e.g. https://github.com/dandi/dandi-cli/blob/master/.pre-commit-config.yaml#L21