### PR TITLE
Add github action to shellcheck master on push and PRs

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,26 @@
+---
+name: Shellcheck
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: Check shell scripts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt update && sudo apt install -y shellcheck
+      - name: shellcheck
+        run: |
+          git grep -l '^#\( *shellcheck \|!\(/bin/\|/usr/bin/env \)\(sh\|bash\|dash\|ksh\)\)' | xargs shellcheck


### PR DESCRIPTION
ATM this one identifies lots of warnings and one likely error

```
In installer/docker/check_x_port.sh line 3:
[[ DISPLAY ]] || {
   ^-----^ SC2078 (error): This expression is constant. Did you forget a $ somewhere?

```

which you might like to address, but instead of an issue decided to file a PR right away 

<details>
<summary>warnings to be addressed -- should be also shown in the action outputs which should now fail</summary> 

```shell
In hnn.sh line 31:
then python3 hnn.py -paramf $paramf -dataf $dataf
                            ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                           ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
then python3 hnn.py -paramf "$paramf" -dataf "$dataf"


In hnn.sh line 33:
then python3 hnn.py -paramf $paramf
                            ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
then python3 hnn.py -paramf "$paramf"


In hnn.sh line 35:
then python3 hnn.py -dataf $dataf
                           ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
then python3 hnn.py -dataf "$dataf"


In hnn_docker.sh line 16:
  echo "Error: ${BASH_SOURCE[0]} (L:$BASH_LINENO) expects UID to be set" >> "$LOGFILE"
                                    ^----------^ SC2128 (warning): Expanding an array without an index only gives the first element.


In hnn_docker.sh line 20:
[[ $LOGFILE ]] || export LOGFILE="$(pwd)/hnn_docker.log"
                         ^-----^ SC2155 (warning): Declare and assign separately to avoid masking return values.


In hnn_docker.sh line 21:
source scripts/docker_functions.sh
       ^-------------------------^ SC1091 (info): Not following: scripts/docker_functions.sh was not specified as input (see shellcheck -x).


In hnn_docker.sh line 24:
if [[ $? -ne 0 ]]; then
      ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In hnn_docker.sh line 63:
if  [[ ! -z "${DOCKER_MACHINE_NAME}" ]]; then
       ^-- SC2236 (style): Use -n instead of ! -z.


In hnn_docker.sh line 73:
if [[ $? -ne "0" ]]; then
      ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In hnn_docker.sh line 76:
  if [[ $? -eq 0 ]]; then
        ^-- SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In hnn_docker.sh line 80:
    eval $("${docker_machine}" env -u 2> /dev/null)
         ^-- SC2046 (warning): Quote this to prevent word splitting.
            ^---------------^ SC2154 (warning): docker_machine is referenced but not assigned.


In hnn_docker.sh line 81:
    eval $("${docker_machine}" env 2> /dev/null)
         ^-- SC2046 (warning): Quote this to prevent word splitting.


In hnn_docker.sh line 84:
    if [[ $? -ne 0 ]]; then
          ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In hnn_docker.sh line 93:
if [[ $? -ne "0" ]]; then
      ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In hnn_docker.sh line 100:
  if [[ $? -ne 0 ]]; then
        ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In hnn_docker.sh line 120:
  if [[ $? -eq "0" ]]; then
        ^-- SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In hnn_docker.sh line 131:
    read -p "Are you sure that you want to remove the HNN image? (y/n)" yn
    ^--^ SC2162 (info): read without -r will mangle backslashes.


In hnn_docker.sh line 151:
  if [[ $? -ne 0 ]]; then
        ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In hnn_docker.sh line 153:
    if [[ $? -ne 0 ]]; then
          ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In hnn_docker.sh line 164:
    if [[ $? -ne 0 ]]; then
          ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In hnn_docker.sh line 170:
    if [[ $? -ne 0 ]]; then
          ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In hnn_docker.sh line 179:
  if [[ $? -ne 0 ]]; then
        ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In hnn_docker.sh line 188:
  if [[ $? -ne "0" ]]; then
        ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In hnn_docker.sh line 194:
        if [[ $? -ne "0" ]]; then
              ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In hnn_docker.sh line 206:
  if [[ $? -ne "0" ]]; then
        ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In hnn_docker.sh line 212:
if [[ $? -ne 0 ]]; then
      ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In hnn_docker.sh line 213:
  NEW_XAUTH_KEYS=1
  ^------------^ SC2034 (warning): NEW_XAUTH_KEYS appears unused. Verify use (or export if used externally).


In hnn_docker.sh line 220:
    if [[ $? -ne 0 ]]; then
          ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In hnn_docker.sh line 229:
    if [[ $? -ne 0 ]]; then
          ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In hnn_docker.sh line 238:
KEYS_TO_CONVERT=$(echo "$(get_host_xauth_keys)" | grep -v '^ffff')  # we know get_xauth_keys will succeed after above
                       ^----------------------^ SC2005 (style): Useless echo? Instead of 'echo $(cmd)', just use 'cmd'.


In hnn_docker.sh line 242:
  echo -e "\n  ** Command: \"${xauth_cmd}\" nlist $DISPLAY | sed -e 's/^..../ffff/' | \"${xauth_cmd}\" -f \"$XAUTHORITY\" -b -i nmerge -" >> "$LOGFILE"
  ^-- SC2129 (style): Consider using { cmd1; cmd2; } >> file instead of individual redirects.


In hnn_docker.sh line 245:
  if [[ "$?" -ne "0" ]] || [[ -f "${XAUTHORITY}-n" ]]; then
        ^--^ SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In hnn_docker.sh line 256:
  if [[ $? -ne "0" ]]; then
        ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In hnn_docker.sh line 262:
if [[ $? -ne "0" ]]; then
      ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In hnn_docker.sh line 272:
if [[ $? -eq "0" ]]; then
      ^-- SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In hnn_docker.sh line 276:
  if [[ $? -eq "0" ]]; then
        ^-- SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In hnn_docker.sh line 284:
    if [[ $? -eq 0 ]]; then
          ^-- SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In hnn_docker.sh line 290:
        if [[ $? -eq "0" ]]; then
              ^-- SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In hnn_docker.sh line 326:
if [[ $? -ne 0 ]]; then
      ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In hnn_docker.sh line 343:
  if [[ $? -ne 0 ]]; then
        ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In hnn_docker.sh line 357:
    if [[ $? -ne 0 ]]; then
          ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In hnn_docker.sh line 366:
  if [[ $? -ne 0 ]]; then
        ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In hnn_docker.sh line 370:
    RETRY=1
    ^---^ SC2034 (warning): RETRY appears unused. Verify use (or export if used externally).


In hnn_docker.sh line 374:
    if [[ $? -ne 0 ]]; then
          ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In installer/aws/aws-build.sh line 25:
cd $HOME && \
   ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
cd "$HOME" && \


In installer/aws/aws-build.sh line 27:
  cd hnn
  ^----^ SC2164 (warning): Use 'cd ... || exit' or 'cd ... || return' in case cd fails.

Did you mean: 
  cd hnn || exit


In installer/aws/aws-build.sh line 30:
echo 'cd $HOME/hnn' | sudo tee -a /usr/local/bin/hnn
     ^------------^ SC2016 (info): Expressions don't expand in single quotes, use double quotes for that.


In installer/brown_ccv/oscar_setup.sh line 5:
mkdir -p $HOME/HNN
         ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
mkdir -p "$HOME"/HNN


In installer/brown_ccv/oscar_setup.sh line 8:
cd $HOME/HNN
^----------^ SC2164 (warning): Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
   ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
cd "$HOME"/HNN || exit


In installer/brown_ccv/oscar_setup.sh line 15:
cd $HOME/HNN/hnn && \
   ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
cd "$HOME"/HNN/hnn && \


In installer/brown_ccv/oscar_setup.sh line 20:
cat <<EOF | tee -a $HOME/.bash_profile > /dev/null
                   ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
cat <<EOF | tee -a "$HOME"/.bash_profile > /dev/null


In installer/brown_ccv/oscar_setup.sh line 39:
cd $HOME/HNN/hnn
^--------------^ SC2164 (warning): Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
   ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
cd "$HOME"/HNN/hnn || exit


In installer/centos/hnn-centos7.sh line 18:
echo $startdir
     ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
echo "$startdir"


In installer/centos/hnn-centos7.sh line 25:
cd $startdir && \
   ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
cd "$startdir" && \


In installer/centos/hnn-centos7.sh line 31:
    mkdir -p $HOME/.local/share/icons && \
             ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    mkdir -p "$HOME"/.local/share/icons && \


In installer/centos/hnn-centos7.sh line 32:
    cp -f hnn.png $HOME/.local/share/icons/ && \
                  ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    cp -f hnn.png "$HOME"/.local/share/icons/ && \


In installer/centos/hnn-centos7.sh line 33:
    cp -f hnn.desktop $HOME/Desktop && \
                      ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    cp -f hnn.desktop "$HOME"/Desktop && \


In installer/centos/hnn-centos7.sh line 34:
    sed -i "s~/home/hnn_user~$startdir~g" $HOME/Desktop/hnn.desktop && \
                                          ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    sed -i "s~/home/hnn_user~$startdir~g" "$HOME"/Desktop/hnn.desktop && \


In installer/centos/hnn-centos7.sh line 35:
    chmod +x $HOME/Desktop/hnn.desktop
             ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    chmod +x "$HOME"/Desktop/hnn.desktop


In installer/docker/check_hnn_out_perms.sh line 15:
  if [[ $? -ne 0 ]]; then
        ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In installer/docker/check_sshd_port.sh line 4:
if [[ $? -ne 0 ]]; then
      ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In installer/docker/check_x_port.sh line 3:
[[ DISPLAY ]] || {
   ^-----^ SC2078 (error): This expression is constant. Did you forget a $ somewhere?


In installer/docker/check_x_port.sh line 8:
let PORT=6000+${DISPLAY#*:}
^-------------------------^ SC2219 (style): Instead of 'let expr', prefer (( expr )) .


In installer/docker/check_x_port.sh line 10:
if [ ! -z $IP ]; then
     ^-- SC2236 (style): Use -n instead of ! -z.
          ^-^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
if [ ! -z "$IP" ]; then


In installer/docker/check_x_port.sh line 11:
  nc -zvw3 $IP $PORT
           ^-^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
  nc -zvw3 "$IP" $PORT


In installer/docker/check_x_port.sh line 12:
  if [[ $? -ne 0 ]]; then
        ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In installer/docker/hooks/build line 4:
  --build-arg SOURCE_BRANCH=$SOURCE_BRANCH \
                            ^------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
  --build-arg SOURCE_BRANCH="$SOURCE_BRANCH" \


In installer/docker/hooks/build line 5:
  --build-arg VCS_TAG=`git describe --tags --abbrev=0` \
                      ^-- SC2046 (warning): Quote this to prevent word splitting.
                      ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean: 
  --build-arg VCS_TAG=$(git describe --tags --abbrev=0) \


In installer/docker/hooks/build line 6:
  --build-arg VCS_REF=`git rev-parse --short HEAD` \
                      ^--------------------------^ SC2046 (warning): Quote this to prevent word splitting.
                      ^--------------------------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean: 
  --build-arg VCS_REF=$(git rev-parse --short HEAD) \


In installer/docker/hooks/build line 7:
  --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
                         ^-----------------------------^ SC2046 (warning): Quote this to prevent word splitting.
                         ^-----------------------------^ SC2006 (style): Use $(...) notation instead of legacy backticks `...`.

Did you mean: 
  --build-arg BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \


In installer/docker/hooks/build line 8:
  -t $IMAGE_NAME .
     ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
  -t "$IMAGE_NAME" .


In installer/docker/start_hnn.sh line 17:
source "$HOME/hnn_envs"
       ^--------------^ SC1091 (info): Not following: ./hnn_envs was not specified as input (see shellcheck -x).


In installer/docker/start_hnn.sh line 18:
cd "$HOME/hnn_source_code"
^------------------------^ SC2164 (warning): Use 'cd ... || exit' or 'cd ... || return' in case cd fails.

Did you mean: 
cd "$HOME/hnn_source_code" || exit


In installer/docker/start_hnn.sh line 27:
    if [[ $? -eq 0 ]]; then
          ^-- SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In installer/docker/start_hnn.sh line 31:
      if [[ $? -eq 0 ]]; then
            ^-- SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In installer/docker/start_hnn.sh line 43:
if [[ $? -eq 0 ]]; then
      ^-- SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In installer/docker/start_hnn.sh line 49:
    if [[ $? -ne 0 ]]; then
          ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In installer/docker/start_hnn.sh line 61:
  if [[ $? -eq 0 ]]; then
        ^-- SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In installer/docker/start_hnn.sh line 65:
    let __port=6000+${DISPLAY#*:}
    ^---------------------------^ SC2219 (style): Instead of 'let expr', prefer (( expr )) .


In installer/docker/start_hnn.sh line 67:
    if [ ! -z $__ip ]; then
         ^-- SC2236 (style): Use -n instead of ! -z.
              ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    if [ ! -z "$__ip" ]; then


In installer/docker/start_hnn.sh line 68:
      if nc -zvw3 $__ip $__port > /dev/null 2>&1; then
                  ^---^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
      if nc -zvw3 "$__ip" $__port > /dev/null 2>&1; then


In installer/docker/start_hnn.sh line 79:
  if [[ $? -eq 0 ]]; then
        ^-- SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In installer/docker/start_hnn.sh line 84:
  if [[ "$?" -ne "0" ]]; then
        ^--^ SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In installer/docker/start_hnn.sh line 101:
  source activate hnn
         ^------^ SC1091 (info): Not following: activate was not specified as input (see shellcheck -x).


In installer/docker/start_ssh.sh line 14:
if [[ "$DEBUG" = "1" ]]; then
       ^----^ SC2153 (info): Possible misspelling: DEBUG may not be assigned. Did you mean debug?


In installer/mac/check-post.sh line 14:
    SPLITVER=( ${VERSION_STRING//./ } )
               ^--------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In installer/mac/check-post.sh line 62:
if [[ "$?" -eq "0" ]]; then
      ^--^ SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In installer/mac/check-post.sh line 64:
  MINICONDA_FOUND=1
  ^-------------^ SC2034 (warning): MINICONDA_FOUND appears unused. Verify use (or export if used externally).


In installer/mac/check-post.sh line 75:
  if [[ "$?" -eq "0" ]]; then
        ^--^ SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In installer/mac/check-post.sh line 78:
    if [[ "$?" -eq "0" ]]; then
          ^--^ SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In installer/mac/check-post.sh line 109:
if [[ "$?" -eq "0" ]]; then
      ^--^ SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In installer/mac/check-post.sh line 117:
elif [[ "PATH" =~ "NEURON" ]] || [[ "$PATH" =~ "NRN" ]]; then
               ^-- SC2050 (warning): This expression is constant. Did you forget the $ on a variable?


In installer/mac/check-post.sh line 130:
if [[ "$?" -ne "0" ]]; then
      ^--^ SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.


In installer/mac/check-post.sh line 169:
  if [[ "$?" -eq "0" ]] && [[ "$OUTPUT" =~ "hello" ]]; then
        ^--^ SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In installer/mac/check-post.sh line 176:
    echo $OUTPUT
         ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    echo "$OUTPUT"


In installer/mac/check-post.sh line 188:
  if [[ "$?" -eq "0" ]]; then
        ^--^ SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In installer/mac/check-post.sh line 196:
    echo $OUTPUT
         ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    echo "$OUTPUT"


In installer/mac/check-post.sh line 208:
  if [[ "$?" -eq "0" ]]; then
        ^--^ SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In installer/mac/check-post.sh line 224:
  if [[ "$?" -eq "0" ]]; then
        ^--^ SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In installer/mac/check-post.sh line 226:
    NRNIV_AND_PYTHON_WORKS=1
    ^--------------------^ SC2034 (warning): NRNIV_AND_PYTHON_WORKS appears unused. Verify use (or export if used externally).


In installer/mac/check-post.sh line 232:
    echo $OUTPUT
         ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    echo "$OUTPUT"


In installer/mac/check-post.sh line 241:
source ${CONDA_PREFIX}/etc/conda/activate.d/env_vars.sh > /dev/null 2>&1
       ^-- SC1091 (info): Not following: ./etc/conda/activate.d/env_vars.sh was not specified as input (see shellcheck -x).
       ^-------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
source "${CONDA_PREFIX}"/etc/conda/activate.d/env_vars.sh > /dev/null 2>&1


In installer/mac/check-post.sh line 242:
if [[ "$?" -eq "0" ]] && [[ -n "${LD_LIBRARY_PATH}" ]]; then
      ^--^ SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In installer/mac/check-post.sh line 256:
  if [[ "$?" -eq "0" ]]; then
        ^--^ SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In installer/mac/check-post.sh line 263:
    if [[ "$?" -eq "0" ]]; then
          ^--^ SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In installer/mac/check-post.sh line 277:
      echo $OUTPUT
           ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
      echo "$OUTPUT"


In installer/mac/check-post.sh line 293:
 if [[ "$?" -eq "0" ]]; then
       ^--^ SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In installer/mac/check-post.sh line 295:
   NRNIV_AND_PYTHON_AND_MPI_WORKS=1
   ^----------------------------^ SC2034 (warning): NRNIV_AND_PYTHON_AND_MPI_WORKS appears unused. Verify use (or export if used externally).


In installer/mac/check-post.sh line 301:
   echo $OUTPUT
        ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
   echo "$OUTPUT"


In installer/mac/check-pre.sh line 6:
[[ $1 ]] && VERBOSE=1
            ^-----^ SC2034 (warning): VERBOSE appears unused. Verify use (or export if used externally).


In installer/mac/check-pre.sh line 19:
    SPLITVER=( ${VERSION_STRING//./ } )
               ^--------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In installer/mac/check-pre.sh line 38:
  if [[ "$?" -eq "0" ]]; then
        ^--^ SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In installer/mac/check-pre.sh line 41:
    if [[ "$?" -eq "0" ]]; then
          ^--^ SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In installer/mac/check-pre.sh line 59:
    echo "Existing version ${PYTHON_VERSION} ($(which $PYTHON)) is not compatible with HNN."
                                                      ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    echo "Existing version ${PYTHON_VERSION} ($(which "$PYTHON")) is not compatible with HNN."


In installer/mac/check-pre.sh line 60:
    echo "HNN requires at least Python ${PYTHON_REQ_MAJ}.${PYTHON_REQ_MIN}"
                                                         ^---------------^ SC2153 (info): Possible misspelling: PYTHON_REQ_MIN may not be assigned. Did you mean PYTHON_REQ_MAJ?


In installer/mac/check-pre.sh line 74:
if [[ "$?" -eq "0" ]]; then
      ^--^ SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.


In installer/mac/check-pre.sh line 80:
elif [[ "PATH" =~ "NEURON" ]] || [[ "$PATH" =~ "NRN" ]]; then
               ^-- SC2050 (warning): This expression is constant. Did you forget the $ on a variable?


In installer/ubuntu/hnn-ubuntu.sh line 9:
  let __retries=5
  ^-------------^ SC2219 (style): Instead of 'let expr', prefer (( expr )) .


In installer/ubuntu/hnn-ubuntu.sh line 22:
  wait $1 && {
       ^-- SC2086 (info): Double quote to prevent globbing and word splitting.
          ^-- SC2015 (info): Note that A && B || C is not if-then-else. C may run when A is true.

Did you mean: 
  wait "$1" && {


In installer/ubuntu/hnn-ubuntu.sh line 64:
sudo -E apt-get update &>> "$LOGFILE"
                        ^-- SC2024 (warning): sudo doesn't affect redirects. Use .. | sudo tee -a file


In installer/ubuntu/hnn-ubuntu.sh line 67:
if [[ "${PYTHON_VERSION}" =~ "3.7" ]] && [[ "$DISTRIB" =~ "bionic" ]]; then
                             ^---^ SC2076 (warning): Remove quotes from right-hand side of =~ to match as a regex rather than literally.


In installer/ubuntu/hnn-ubuntu.sh line 68:
  sudo -E apt-get install --no-install-recommends -y python3.7 python3-pip python3.7-tk python3.7-dev &>> "$LOGFILE" && \
                                                                                                       ^-- SC2024 (warning): sudo doesn't affect redirects. Use .. | sudo tee -a file


In installer/ubuntu/hnn-ubuntu.sh line 69:
    sudo python3.7 -m pip install --upgrade pip setuptools &>> "$LOGFILE"
                                                            ^-- SC2024 (warning): sudo doesn't affect redirects. Use .. | sudo tee -a file


In installer/ubuntu/hnn-ubuntu.sh line 73:
  sudo -E apt-get install --no-install-recommends -y python3 python3-pip python3-tk python3-setuptools &>> "$LOGFILE" && \
                                                                                                        ^-- SC2024 (warning): sudo doesn't affect redirects. Use .. | sudo tee -a file


In installer/ubuntu/hnn-ubuntu.sh line 74:
    sudo pip3 install --upgrade pip &>> "$LOGFILE"
                                     ^-- SC2024 (warning): sudo doesn't affect redirects. Use .. | sudo tee -a file


In installer/ubuntu/hnn-ubuntu.sh line 78:
  export PYTHON=$(which python3)
         ^----^ SC2155 (warning): Declare and assign separately to avoid masking return values.


In installer/ubuntu/hnn-ubuntu.sh line 85:
  export PYTHON=$(which python)
         ^----^ SC2155 (warning): Declare and assign separately to avoid masking return values.


In installer/ubuntu/hnn-ubuntu.sh line 93:
        make gcc g++ python3-dev &>> "$LOGFILE"
                                  ^-- SC2024 (warning): sudo doesn't affect redirects. Use .. | sudo tee -a file


In installer/ubuntu/hnn-ubuntu.sh line 100:
  echo 'export PATH="$PATH:$HOME/.local/bin"' >> ~/.bashrc
       ^-- SC2016 (info): Expressions don't expand in single quotes, use double quotes for that.


In installer/ubuntu/hnn-ubuntu.sh line 163:
        libxcb-xinerama0 libxcb-xfixes0 &>> "$LOGFILE"
                                         ^-- SC2024 (warning): sudo doesn't affect redirects. Use .. | sudo tee -a file


In installer/ubuntu/hnn-ubuntu.sh line 167:
sudo -E apt-get clean &>> "$LOGFILE"
                       ^-- SC2024 (warning): sudo doesn't affect redirects. Use .. | sudo tee -a file


In scripts/setup-travis-linux.sh line 7:
Xvfb $DISPLAY -listen tcp -screen 0 1024x768x24 > /dev/null &
     ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
Xvfb "$DISPLAY" -listen tcp -screen 0 1024x768x24 > /dev/null &


In scripts/setup-travis-linux.sh line 13:
xset -display $DISPLAY -q > /dev/null;
              ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
xset -display "$DISPLAY" -q > /dev/null;


In scripts/setup-travis-osx.sh line 7:
source "$DIR/utils.sh"
       ^-------------^ SC1091 (info): Not following: ./utils.sh was not specified as input (see shellcheck -x).


In scripts/setup-travis-osx.sh line 15:
source "$HOME/Miniconda3/etc/profile.d/conda.sh"
       ^-- SC1091 (info): Not following: ./Miniconda3/etc/profile.d/conda.sh was not specified as input (see shellcheck -x).


In scripts/setup-travis-windows.sh line 17:
reg add HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Lsa //t REG_DWORD //v LimitBlankPasswordUse //d 0 //f 2>&1 > /dev/null
                                                                                                                      ^--^ SC2069 (warning): To redirect stdout+stderr, 2>&1 must be last (or use '{ cmd > file; } 2>&1' to clarify).


In scripts/setup-travis-wsl.sh line 7:
source "$DIR/utils.sh"
       ^-------------^ SC1091 (info): Not following: ./utils.sh was not specified as input (see shellcheck -x).

For more information:
  https://www.shellcheck.net/wiki/SC2078 -- This expression is constant. Did ...
  https://www.shellcheck.net/wiki/SC2024 -- sudo doesn't affect redirects. Us...
  https://www.shellcheck.net/wiki/SC2034 -- MINICONDA_FOUND appears unused. V...

```
</details>

